### PR TITLE
fix: allow excitation placement on any wire segment

### DIFF
--- a/frontend/src/components/three/EditorAntennaModel.tsx
+++ b/frontend/src/components/three/EditorAntennaModel.tsx
@@ -9,7 +9,7 @@
  * - Feedpoint marker overlay
  */
 
-import { useMemo, useCallback } from "react";
+import { useMemo, useCallback, useState, useRef } from "react";
 import {
   TubeGeometry,
   LineCurve3,
@@ -26,6 +26,12 @@ interface EditorAntennaModelProps {
   wire: WireData;
   isSelected: boolean;
   hasFeedpoint: boolean;
+  /** Actual excitation segment number (1-based), or undefined if no excitation */
+  feedSegment?: number;
+  /** Whether this wire is in "pick excitation segment" mode */
+  isPicking: boolean;
+  /** Show feedpoint marker at exact NEC2 segment center */
+  accurateFeedpoint?: boolean;
   mode: EditorMode;
   onWireClick: (tag: number, event: ThreeEvent<MouseEvent>) => void;
   onEndpointDragStart?: (
@@ -38,20 +44,66 @@ interface EditorAntennaModelProps {
     tag: number,
     event: ThreeEvent<PointerEvent>
   ) => void;
+  /** Called when a segment is picked in pick mode */
+  onSegmentPick?: (tag: number, segment: number) => void;
+  /** Ref to the tooltip DOM element for showing segment info on hover */
+  tooltipRef?: { current: HTMLDivElement | null };
 }
 
 const SELECTED_COLOR = "#FFFFFF";
 const FEEDPOINT_COLOR = "#F59E0B";
 
+/** Compute the 3D position of a segment along a wire (in Three.js coords).
+ *  When accurate=false (default), endpoint segments snap to wire edges for cleaner junction visuals.
+ *  When accurate=true, always positions at the NEC2 segment center. */
+function segmentPosition(
+  wireStart: Vector3,
+  wireEnd: Vector3,
+  segment: number,
+  totalSegments: number,
+  accurate = false
+): Vector3 {
+  if (!accurate) {
+    if (segment === 1) return wireStart.clone();
+    if (segment === totalSegments) return wireEnd.clone();
+  }
+  const t = (segment - 0.5) / totalSegments;
+  return wireStart.clone().lerp(wireEnd, t);
+}
+
+/** Compute which segment (1-based) a point along the wire falls into. */
+function pointToSegment(
+  wireStart: Vector3,
+  wireEnd: Vector3,
+  point: Vector3,
+  totalSegments: number
+): number {
+  const wireDir = wireEnd.clone().sub(wireStart);
+  const lenSq = wireDir.lengthSq();
+  if (lenSq === 0) return 1;
+  const toPoint = point.clone().sub(wireStart);
+  const t = Math.max(0, Math.min(1, toPoint.dot(wireDir) / lenSq));
+  return Math.max(1, Math.min(totalSegments, Math.ceil(t * totalSegments) || 1));
+}
+
 export function EditorAntennaModel({
   wire,
   isSelected,
   hasFeedpoint,
+  feedSegment,
+  isPicking,
+  accurateFeedpoint,
   mode,
   onWireClick,
   onEndpointDragStart,
   onWireDragStart,
+  onSegmentPick,
+  tooltipRef,
 }: EditorAntennaModelProps) {
+  // Pick mode: hovered segment number (null when not hovering)
+  const [hoveredSegment, setHoveredSegment] = useState<number | null>(null);
+  const lastPointerEvent = useRef<{ clientX: number; clientY: number } | null>(null);
+
   const { geometry, material, start, end } = useMemo(() => {
     // NEC2: X=east, Y=north, Z=up -> Three.js: X=east, Y=up, Z=south
     const s = new Vector3(wire.x1, wire.z1, -wire.y1);
@@ -112,12 +164,17 @@ export function EditorAntennaModel({
   }, [hasFeedpoint]);
 
   const feedpointPosition = useMemo((): [number, number, number] => {
+    if (feedSegment && wire.segments > 0) {
+      const pos = segmentPosition(start, end, feedSegment, wire.segments, accurateFeedpoint);
+      return [pos.x, pos.y, pos.z];
+    }
+    // Fallback to center if no segment info
     return [
       (start.x + end.x) / 2,
       (start.y + end.y) / 2,
       (start.z + end.z) / 2,
     ];
-  }, [start, end]);
+  }, [start, end, feedSegment, wire.segments, accurateFeedpoint]);
 
   const handleClick = useCallback(
     (event: ThreeEvent<MouseEvent>) => {
@@ -138,6 +195,52 @@ export function EditorAntennaModel({
     [mode, wire.tag, onWireDragStart]
   );
 
+  /** Pick mode: compute hovered segment and update tooltip */
+  const handlePickPointerMove = useCallback(
+    (event: ThreeEvent<PointerEvent>) => {
+      if (!isPicking) return;
+      const seg = pointToSegment(start, end, event.point, wire.segments);
+      setHoveredSegment(seg);
+      lastPointerEvent.current = { clientX: event.nativeEvent.clientX, clientY: event.nativeEvent.clientY };
+      // Update tooltip
+      if (tooltipRef?.current) {
+        const el = tooltipRef.current;
+        el.style.display = "block";
+        el.style.left = `${event.nativeEvent.clientX + 12}px`;
+        el.style.top = `${event.nativeEvent.clientY - 8}px`;
+        el.textContent = `Seg ${seg} of ${wire.segments}`;
+      }
+    },
+    [isPicking, start, end, wire.segments, tooltipRef]
+  );
+
+  /** Pick mode: hide tooltip on pointer leave */
+  const handlePickPointerLeave = useCallback(() => {
+    setHoveredSegment(null);
+    lastPointerEvent.current = null;
+    if (tooltipRef?.current) {
+      tooltipRef.current.style.display = "none";
+    }
+  }, [tooltipRef]);
+
+  /** Pick mode: set excitation at the clicked segment */
+  const handlePickClick = useCallback(
+    (event: ThreeEvent<MouseEvent>) => {
+      if (!isPicking || !onSegmentPick) return;
+      event.stopPropagation();
+      const seg = pointToSegment(start, end, event.point, wire.segments);
+      onSegmentPick(wire.tag, seg);
+    },
+    [isPicking, onSegmentPick, start, end, wire.segments, wire.tag]
+  );
+
+  // Preview marker position (ghost feedpoint while hovering in pick mode)
+  const previewPosition = useMemo((): [number, number, number] | null => {
+    if (!isPicking || hoveredSegment === null) return null;
+    const pos = segmentPosition(start, end, hoveredSegment, wire.segments, accurateFeedpoint);
+    return [pos.x, pos.y, pos.z];
+  }, [isPicking, hoveredSegment, start, end, wire.segments, accurateFeedpoint]);
+
   const capRadius = Math.max(wire.radius * 60, 0.04);
   const endpointRadius = mode === "move" ? capRadius * 2.5 : capRadius;
   const endpointColor = mode === "move" ? "#10B981" : getWireColor(wire.tag);
@@ -149,12 +252,14 @@ export function EditorAntennaModel({
         <mesh geometry={outlineGeometry} material={outlineMaterial} />
       )}
 
-      {/* Wire tube — clickable for selection, draggable for whole-wire move */}
+      {/* Wire tube — clickable for selection, draggable for whole-wire move, pick mode interactions */}
       <mesh
         geometry={geometry}
         material={material}
-        onClick={handleClick}
-        onPointerDown={handleWirePointerDown}
+        onClick={isPicking ? handlePickClick : handleClick}
+        onPointerDown={isPicking ? undefined : handleWirePointerDown}
+        onPointerMove={isPicking ? handlePickPointerMove : undefined}
+        onPointerLeave={isPicking ? handlePickPointerLeave : undefined}
       />
 
       {/* Endpoint spheres */}
@@ -201,10 +306,24 @@ export function EditorAntennaModel({
         />
       </mesh>
 
-      {/* Feedpoint glow */}
+      {/* Feedpoint glow — positioned at actual excitation segment */}
       {hasFeedpoint && feedpointMat && (
         <mesh position={feedpointPosition} material={feedpointMat}>
           <sphereGeometry args={[capRadius * 3, 16, 16]} />
+        </mesh>
+      )}
+
+      {/* Pick mode: ghost preview marker at hovered segment */}
+      {previewPosition && (
+        <mesh position={previewPosition}>
+          <sphereGeometry args={[capRadius * 3, 16, 16]} />
+          <meshPhysicalMaterial
+            color="#3B82F6"
+            emissive="#3B82F6"
+            emissiveIntensity={1.5}
+            transparent
+            opacity={0.6}
+          />
         </mesh>
       )}
     </group>

--- a/frontend/src/components/three/EditorScene.tsx
+++ b/frontend/src/components/three/EditorScene.tsx
@@ -12,7 +12,7 @@
  */
 
 import { Canvas, useThree, ThreeEvent } from "@react-three/fiber";
-import { Suspense, useMemo, useCallback, useState, useRef } from "react";
+import { Suspense, useMemo, useCallback, useState, useRef, type RefObject } from "react";
 import { ACESFilmicToneMapping, SRGBColorSpace, Vector3, Plane, LineCurve3, TubeGeometry, MeshBasicMaterial } from "three";
 import { GroundPlane } from "./GroundPlane";
 import { CompassRose } from "./CompassRose";
@@ -38,6 +38,7 @@ interface EditorSceneProps {
   patternData?: PatternData | null;
   currents?: SegmentCurrent[] | null;
   nearField?: NearFieldResult | null;
+  tooltipRef?: RefObject<HTMLDivElement | null>;
 }
 
 /** Ground plane for raycasting (XZ plane at y=0 in Three.js = z=0 in NEC2) */
@@ -82,8 +83,10 @@ function EditorSceneContent({
   patternData,
   currents,
   nearField,
+  tooltipRef,
 }: EditorSceneProps) {
   const theme = useUIStore((s) => s.theme);
+  const accurateFeedpoint = useUIStore((s) => s.accurateFeedpoint);
 
   const wires = useEditorStore((s) => s.wires);
   const excitations = useEditorStore((s) => s.excitations);
@@ -96,6 +99,27 @@ function EditorSceneContent({
   const updateWire = useEditorStore((s) => s.updateWire);
   const moveWire = useEditorStore((s) => s.moveWire);
   const toggleSelection = useEditorStore((s) => s.toggleSelection);
+  const pickingExcitationForTag = useEditorStore((s) => s.pickingExcitationForTag);
+  const setExcitation = useEditorStore((s) => s.setExcitation);
+  const setPickingExcitationForTag = useEditorStore((s) => s.setPickingExcitationForTag);
+
+  /** Handle segment pick in 3D viewport — sets excitation and exits pick mode */
+  const handleSegmentPick = useCallback(
+    (tag: number, segment: number) => {
+      setExcitation(tag, segment);
+      setPickingExcitationForTag(null);
+    },
+    [setExcitation, setPickingExcitationForTag]
+  );
+
+  /** Build a map from wire tag to excitation segment for quick lookup */
+  const excitationSegmentMap = useMemo(() => {
+    const map = new Map<number, number>();
+    for (const e of excitations) {
+      map.set(e.wire_tag, e.segment);
+    }
+    return map;
+  }, [excitations]);
 
   // Add mode state: first click sets start point, second click sets end
   const [addStart, setAddStart] = useState<[number, number, number] | null>(null);
@@ -382,10 +406,15 @@ function EditorSceneContent({
             wire={wire}
             isSelected={selectedTags.has(wire.tag)}
             hasFeedpoint={feedpointTags.has(wire.tag)}
+            feedSegment={excitationSegmentMap.get(wire.tag)}
+            isPicking={pickingExcitationForTag === wire.tag}
+            accurateFeedpoint={accurateFeedpoint}
             mode={mode}
             onWireClick={handleWireClick}
             onEndpointDragStart={handleEndpointDragStart}
             onWireDragStart={handleWireDragStart}
+            onSegmentPick={handleSegmentPick}
+            tooltipRef={tooltipRef}
           />
         ))}
 
@@ -451,6 +480,7 @@ function EditorSceneContent({
 
 export function EditorScene({ viewToggles, patternData, currents, nearField }: EditorSceneProps) {
   const theme = useUIStore((s) => s.theme);
+  const isPicking = useEditorStore((s) => s.pickingExcitationForTag) !== null;
   const sceneBg = theme === "dark" ? "#0A0A0F" : "#E8E8ED";
 
   // Tooltip ref — direct DOM mutation, no React state
@@ -471,10 +501,10 @@ export function EditorScene({ viewToggles, patternData, currents, nearField }: E
     <Canvas
       gl={glConfig}
       camera={{ position: [15, 12, 15], fov: 50, near: 0.1, far: 500 }}
-      style={{ background: sceneBg }}
+      style={{ background: sceneBg, cursor: isPicking ? "crosshair" : undefined }}
     >
       <Suspense fallback={null}>
-        <EditorSceneContent viewToggles={viewToggles} patternData={patternData} currents={currents} nearField={nearField} />
+        <EditorSceneContent viewToggles={viewToggles} patternData={patternData} currents={currents} nearField={nearField} tooltipRef={tooltipRef} />
         <SceneRaycaster tooltipRef={tooltipRef} />
       </Suspense>
     </Canvas>

--- a/frontend/src/pages/EditorPage.tsx
+++ b/frontend/src/pages/EditorPage.tsx
@@ -387,7 +387,7 @@ export function EditorPage() {
                 <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" className={`transition-transform ${wirePropsOpen ? "rotate-180" : ""}`}><path d="M6 9l6 6 6-6" /></svg>
               </button>
               {wirePropsOpen && (
-                <div className="min-h-[150px] max-h-[300px] overflow-y-auto">
+                <div className="min-h-[150px] max-h-[480px] overflow-y-auto">
                   <WirePropertiesPanel />
                 </div>
               )}

--- a/frontend/src/stores/editorStore.ts
+++ b/frontend/src/stores/editorStore.ts
@@ -123,6 +123,9 @@ interface EditorState {
   setDesignFrequency: (mhz: number) => void;
 
   // ---- Excitation ----
+  /** Wire tag currently in "pick segment on viewport" mode, or null */
+  pickingExcitationForTag: number | null;
+  setPickingExcitationForTag: (tag: number | null) => void;
   setExcitation: (wireTag: number, segment: number) => void;
   removeExcitation: (wireTag: number) => void;
 
@@ -184,7 +187,7 @@ function computeSegments(wire: { x1: number; y1: number; z1: number; x2: number;
 }
 
 /** Ensure all excitation segment indices are valid for their wire's segment count.
- *  If an excitation references a segment beyond the wire's count, re-center it. */
+ *  If an excitation references a segment beyond the wire's count, clamp it. */
 function fixExcitations(excitations: Excitation[], wires: EditorWire[]): Excitation[] {
   let changed = false;
   const fixed = excitations.map((e) => {
@@ -192,7 +195,7 @@ function fixExcitations(excitations: Excitation[], wires: EditorWire[]): Excitat
     if (!wire) return e;
     if (e.segment > wire.segments) {
       changed = true;
-      return { ...e, segment: centerSegment(wire.segments) };
+      return { ...e, segment: Math.min(e.segment, wire.segments) };
     }
     return e;
   });
@@ -363,10 +366,24 @@ export const useEditorStore = create<EditorState>((set, get) => ({
       segments: computeSegments({ x1: midX, y1: midY, z1: midZ, x2: wire.x2, y2: wire.y2, z2: wire.z2 }, state.designFrequencyMhz),
     };
 
-    // Update excitations if they reference the split wire
+    // Update excitations if they reference the split wire.
+    // Map segment to the correct half based on its original position.
+    const halfSegment = Math.ceil(wire.segments / 2);
     const newExcitations = state.excitations.map((e) => {
       if (e.wire_tag === tag) {
-        return { ...e, wire_tag: tag1, segment: centerSegment(wire1.segments) };
+        if (e.segment <= halfSegment) {
+          // Falls in first half — scale into wire1's segment range
+          const ratio = e.segment / halfSegment;
+          const newSeg = Math.max(1, Math.min(wire1.segments, Math.round(ratio * wire1.segments)));
+          return { ...e, wire_tag: tag1, segment: newSeg };
+        } else {
+          // Falls in second half — scale into wire2's segment range
+          const offsetInSecondHalf = e.segment - halfSegment;
+          const secondHalfTotal = wire.segments - halfSegment;
+          const ratio = offsetInSecondHalf / secondHalfTotal;
+          const newSeg = Math.max(1, Math.min(wire2.segments, Math.round(ratio * wire2.segments)));
+          return { ...e, wire_tag: tag2, segment: newSeg };
+        }
       }
       return e;
     });
@@ -465,11 +482,14 @@ export const useEditorStore = create<EditorState>((set, get) => ({
       ...w,
       segments: computeSegments(w, mhz),
     }));
-    // Update excitation segments
+    // Scale excitation segments proportionally to preserve relative position
     const newExcitations = state.excitations.map((e) => {
-      const wire = newWires.find((w) => w.tag === e.wire_tag);
-      if (wire) {
-        return { ...e, segment: centerSegment(wire.segments) };
+      const oldWire = state.wires.find((w) => w.tag === e.wire_tag);
+      const newWire = newWires.find((w) => w.tag === e.wire_tag);
+      if (oldWire && newWire && oldWire.segments !== newWire.segments) {
+        const ratio = e.segment / oldWire.segments;
+        const scaled = Math.max(1, Math.min(newWire.segments, Math.round(ratio * newWire.segments)));
+        return { ...e, segment: scaled };
       }
       return e;
     });
@@ -490,6 +510,10 @@ export const useEditorStore = create<EditorState>((set, get) => ({
   },
 
   // ---- Excitation ----
+
+  pickingExcitationForTag: null,
+
+  setPickingExcitationForTag: (tag) => set({ pickingExcitationForTag: tag }),
 
   setExcitation: (wireTag, segment) => {
     const state = get();

--- a/frontend/src/stores/uiStore.ts
+++ b/frontend/src/stores/uiStore.ts
@@ -31,6 +31,8 @@ interface UIState {
   s1pFile: S1PFile | null;
   /** Impedance matching (balun/unun) configuration */
   matching: MatchingConfig;
+  /** Show feedpoint marker at exact NEC2 segment center (true) or snapped to wire edge (false) */
+  accurateFeedpoint: boolean;
 
   // Actions
   setTheme: (theme: Theme) => void;
@@ -46,6 +48,7 @@ interface UIState {
   setMobileTab: (tab: MobileTab) => void;
   setS1PFile: (file: S1PFile | null) => void;
   setMatching: (matching: MatchingConfig) => void;
+  setAccurateFeedpoint: (value: boolean) => void;
 }
 
 export const useUIStore = create<UIState>((set) => ({
@@ -71,6 +74,7 @@ export const useUIStore = create<UIState>((set) => ({
   mobileTab: "antenna",
   s1pFile: null,
   matching: { ...DEFAULT_MATCHING },
+  accurateFeedpoint: false,
 
   setTheme: (theme) => set({ theme }),
   toggleTheme: () =>
@@ -91,4 +95,5 @@ export const useUIStore = create<UIState>((set) => ({
   setMobileTab: (tab) => set({ mobileTab: tab }),
   setS1PFile: (file) => set({ s1pFile: file }),
   setMatching: (matching) => set({ matching }),
+  setAccurateFeedpoint: (value) => set({ accurateFeedpoint: value }),
 }));


### PR DESCRIPTION
## Summary
- Allow placing excitation on any wire segment, not just the center
- Add segment picker UI with number input and Start/Center/End quick-pick buttons
- Add "Pick on wire" mode for visual segment selection in the 3D viewport with hover tooltip and preview marker
- Add "Accurate feedpoint" checkbox to toggle between snapped-to-edge and exact NEC2 segment center positioning
- Position feedpoint marker at the actual excitation segment instead of always at wire center
- Fix segment preservation when design frequency changes (proportional scaling) or wires are split
- Increase properties panel max height to avoid inner scrolling

Closes #6