### PR TITLE
fix: support GitHub Pages base path for SPA routing

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -59,6 +59,9 @@ jobs:
           VITE_ENGINE: wasm
         run: npx vite build --base /AntennaSim/
 
+      - name: Create SPA fallback for GitHub Pages
+        run: cp frontend/dist/index.html frontend/dist/404.html
+
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v3
         with:

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,6 +3,9 @@ import { BrowserRouter } from "react-router-dom";
 import { AppRoutes } from "./routes";
 import { useUIStore } from "./stores/uiStore";
 
+/** Basename for the router — matches Vite's base path (e.g. "/AntennaSim/" on GitHub Pages). */
+const basename = import.meta.env.BASE_URL;
+
 export function App() {
   const theme = useUIStore((s) => s.theme);
 
@@ -17,7 +20,7 @@ export function App() {
   }, [theme]);
 
   return (
-    <BrowserRouter>
+    <BrowserRouter basename={basename}>
       <AppRoutes />
     </BrowserRouter>
   );

--- a/frontend/src/components/layout/Navbar.tsx
+++ b/frontend/src/components/layout/Navbar.tsx
@@ -3,7 +3,7 @@
  */
 
 import { useCallback } from "react";
-import { useLocation } from "react-router-dom";
+import { Link, useLocation } from "react-router-dom";
 import { useUIStore } from "../../stores/uiStore";
 
 export function Navbar() {
@@ -26,19 +26,19 @@ export function Navbar() {
     <header className="flex items-center justify-between px-4 h-11 border-b border-border bg-surface shrink-0">
       <div className="flex items-center gap-6">
         {/* Logo */}
-        <a href="/" className="flex items-center gap-2">
+        <Link to="/" className="flex items-center gap-2">
           <span className="text-accent font-bold text-lg tracking-tight">
             AntennaSim
           </span>
           <span className="text-text-secondary text-[10px] font-mono">
             v{__APP_VERSION__}
           </span>
-        </a>
+        </Link>
 
         {/* Nav links */}
         <nav className="hidden md:flex items-center gap-4 text-sm">
-          <a
-            href="/"
+          <Link
+            to="/"
             className={`hover:text-accent transition-colors ${
               location.pathname === "/"
                 ? "text-text-primary font-medium"
@@ -46,9 +46,9 @@ export function Navbar() {
             }`}
           >
             Simulator
-          </a>
-          <a
-            href="/editor"
+          </Link>
+          <Link
+            to="/editor"
             className={`hover:text-accent transition-colors ${
               location.pathname === "/editor"
                 ? "text-accent font-medium"
@@ -56,9 +56,9 @@ export function Navbar() {
             }`}
           >
             Editor
-          </a>
-          <a
-            href="/library"
+          </Link>
+          <Link
+            to="/library"
             className={`hover:text-accent transition-colors ${
               location.pathname === "/library"
                 ? "text-text-primary font-medium"
@@ -66,9 +66,9 @@ export function Navbar() {
             }`}
           >
             Library
-          </a>
-          <a
-            href="/learn"
+          </Link>
+          <Link
+            to="/learn"
             className={`hover:text-accent transition-colors ${
               location.pathname === "/learn"
                 ? "text-text-primary font-medium"
@@ -76,9 +76,9 @@ export function Navbar() {
             }`}
           >
             Learn
-          </a>
-          <a
-            href="/about"
+          </Link>
+          <Link
+            to="/about"
             className={`hover:text-accent transition-colors ${
               location.pathname === "/about"
                 ? "text-text-primary font-medium"
@@ -86,7 +86,7 @@ export function Navbar() {
             }`}
           >
             About
-          </a>
+          </Link>
         </nav>
       </div>
 

--- a/frontend/src/pages/NotFoundPage.tsx
+++ b/frontend/src/pages/NotFoundPage.tsx
@@ -1,15 +1,17 @@
+import { Link } from "react-router-dom";
+
 export function NotFoundPage() {
   return (
     <div className="flex items-center justify-center h-screen">
       <div className="text-center space-y-4">
         <h1 className="text-6xl font-bold text-accent">404</h1>
         <p className="text-text-secondary text-lg">Page not found</p>
-        <a
-          href="/"
+        <Link
+          to="/"
           className="inline-block px-4 py-2 bg-accent text-white rounded-lg hover:bg-accent-hover transition-colors"
         >
           Back to Simulator
-        </a>
+        </Link>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- Add `basename={import.meta.env.BASE_URL}` to `BrowserRouter` so routes resolve correctly under `/AntennaSim/`
- Convert hardcoded `<a href="/">` links in Navbar and NotFoundPage to React Router `<Link to="/">` to prevent full-page reloads that bypass the router
- Copy `index.html` to `404.html` in the deploy workflow so GitHub Pages serves the SPA for all routes (direct access / refresh)
Closes routing 404s on https://EA1FUO.github.io/AntennaSim/