### PR TITLE
fix: use Vite BASE_URL in WASM workers for subpath deployment

### DIFF
--- a/frontend/public/manifest.json
+++ b/frontend/public/manifest.json
@@ -2,13 +2,13 @@
   "name": "AntennaSim — Web Antenna Simulator",
   "short_name": "AntennaSim",
   "description": "Free web-based antenna simulator powered by NEC2",
-  "start_url": "/",
+  "start_url": ".",
   "display": "standalone",
   "background_color": "#0A0A0F",
   "theme_color": "#3B82F6",
   "icons": [
     {
-      "src": "/favicon.svg",
+      "src": "./favicon.svg",
       "sizes": "any",
       "type": "image/svg+xml"
     }

--- a/frontend/src/engine/wasm/worker-optimizer.ts
+++ b/frontend/src/engine/wasm/worker-optimizer.ts
@@ -79,12 +79,14 @@ let createNec2cFactory:
  *
  * Module workers don't support importScripts, so we fetch the Emscripten
  * glue code as text and evaluate it.
+ *
+ * Uses `import.meta.env.BASE_URL` (statically replaced by Vite at build time)
+ * to resolve WASM assets under the correct base path (e.g. `/AntennaSim/`).
  */
 async function ensureFactory(): Promise<void> {
   if (createNec2cFactory) return;
 
-  const wasmBase =
-    (self as unknown as Record<string, string>).__WASM_BASE_URL__ ?? "/";
+  const wasmBase = import.meta.env.BASE_URL;
   const url = `${wasmBase}wasm/nec2c.js`;
   const response = await fetch(url);
   if (!response.ok) {
@@ -114,8 +116,7 @@ async function ensureFactory(): Promise<void> {
 async function createModule(): Promise<Nec2cModule> {
   await ensureFactory();
 
-  const wasmBase =
-    (self as unknown as Record<string, string>).__WASM_BASE_URL__ ?? "/";
+  const wasmBase = import.meta.env.BASE_URL;
   const noop = () => {};
   return createNec2cFactory!({
     locateFile: (path: string) => {

--- a/frontend/src/engine/wasm/worker.ts
+++ b/frontend/src/engine/wasm/worker.ts
@@ -59,13 +59,15 @@ let createNec2cFactory:
  * Module workers don't support importScripts, so we fetch the Emscripten
  * glue code as text and evaluate it. The script defines `createNec2c`
  * on globalThis (self in a worker context).
+ *
+ * Uses `import.meta.env.BASE_URL` (statically replaced by Vite at build time)
+ * to resolve WASM assets under the correct base path (e.g. `/AntennaSim/`).
  */
 async function ensureFactory(): Promise<void> {
   if (createNec2cFactory) return;
 
   // Fetch and evaluate the Emscripten glue code
-  const wasmBase =
-    (self as unknown as Record<string, string>).__WASM_BASE_URL__ ?? "/";
+  const wasmBase = import.meta.env.BASE_URL;
   const url = `${wasmBase}wasm/nec2c.js`;
   const response = await fetch(url);
   if (!response.ok) {
@@ -94,8 +96,7 @@ async function ensureFactory(): Promise<void> {
 async function loadModule(): Promise<Nec2cModule> {
   await ensureFactory();
 
-  const wasmBase =
-    (self as unknown as Record<string, string>).__WASM_BASE_URL__ ?? "/";
+  const wasmBase = import.meta.env.BASE_URL;
 
   const noop = () => {};
   return createNec2cFactory!({


### PR DESCRIPTION
## Summary
- Replace unused `__WASM_BASE_URL__` fallback (`?? "/"`) with `import.meta.env.BASE_URL` in both simulation and optimizer Web Workers — fixes WASM 404 when deployed under `/AntennaSim/` on GitHub Pages
- Use relative paths in `manifest.json` (`"."` / `"./favicon.svg"`) so they resolve correctly under any base path
The `loader.ts` (main thread) already used `BASE_URL` correctly; the workers were the only files still hardcoded to `"/"`. Verified by building with `--base /AntennaSim/` and confirming the minified worker output contains `/AntennaSim/wasm/nec2c.js`.