### PR TITLE
fix: clear stale results on page switch, generate NE cards in WASM, fix compare color index

### DIFF
--- a/frontend/src/engine/parsers/nec-input.ts
+++ b/frontend/src/engine/parsers/nec-input.ts
@@ -142,8 +142,30 @@ export function buildCardDeck(request: SimulateAdvancedRequest): string {
       `${freq.start_mhz.toFixed(6)} ${stepMhz.toFixed(6)}`
   );
 
-  // NE card (near-field) — not included in advanced request type,
-  // but placeholder kept for card ordering if the type is extended.
+  // NE card (near-field) — generates a grid of E-field sample points
+  if (request.near_field) {
+    const nf = request.near_field;
+    if (nf.plane === "horizontal") {
+      const nx = Math.floor(2 * nf.extent_m / nf.resolution_m) + 1;
+      const ny = nx;
+      const nz = 1;
+      lines.push(
+        `NE 0 ${nx} ${ny} ${nz} ` +
+          `${(-nf.extent_m).toFixed(4)} ${(-nf.extent_m).toFixed(4)} ${nf.height_m.toFixed(4)} ` +
+          `${nf.resolution_m.toFixed(4)} ${nf.resolution_m.toFixed(4)} ${(0.0).toFixed(4)}`
+      );
+    } else {
+      // Vertical plane along X axis
+      const nx = Math.floor(2 * nf.extent_m / nf.resolution_m) + 1;
+      const ny = 1;
+      const nz = Math.floor(nf.extent_m / nf.resolution_m) + 1;
+      lines.push(
+        `NE 0 ${nx} ${ny} ${nz} ` +
+          `${(-nf.extent_m).toFixed(4)} ${(0.0).toFixed(4)} ${(0.0).toFixed(4)} ` +
+          `${nf.resolution_m.toFixed(4)} ${(0.0).toFixed(4)} ${nf.resolution_m.toFixed(4)}`
+      );
+    }
+  }
 
   // RP card (radiation pattern)
   const patternStep = request.pattern_step ?? 5;

--- a/frontend/src/engine/types.ts
+++ b/frontend/src/engine/types.ts
@@ -43,6 +43,18 @@ export interface SimulateRequest {
   patternStep?: number;
 }
 
+/** Near-field calculation configuration */
+export interface NearFieldConfig {
+  /** Plane orientation: "horizontal" (XY at fixed Z) or "vertical" (XZ at Y=0) */
+  plane: "horizontal" | "vertical";
+  /** Height of the horizontal plane in metres (e.g. 1.8 for eye level) */
+  height_m: number;
+  /** Half-extent of the grid in metres (grid spans -extent to +extent) */
+  extent_m: number;
+  /** Grid resolution in metres */
+  resolution_m: number;
+}
+
 /** V2: Advanced simulation request (editor mode) */
 export interface SimulateAdvancedRequest {
   wires: WireGeometry[];
@@ -55,6 +67,7 @@ export interface SimulateAdvancedRequest {
   transforms?: GeometryTransformDef[];
   symmetry?: CylindricalSymmetryDef;
   compute_currents?: boolean;
+  near_field?: NearFieldConfig;
   pattern_step?: number;
   comment?: string;
 }

--- a/frontend/src/engine/wasm/index.ts
+++ b/frontend/src/engine/wasm/index.ts
@@ -138,6 +138,12 @@ export class WasmEngine implements SimulationEngine {
       ground: request.ground,
       frequency: request.frequency,
       compute_currents: true,
+      near_field: {
+        plane: "horizontal",
+        height_m: 1.8,
+        extent_m: 20.0,
+        resolution_m: 0.5,
+      },
       pattern_step: request.patternStep,
       comment: "AntennaSim simulation",
     };

--- a/frontend/src/engine/wasm/worker.ts
+++ b/frontend/src/engine/wasm/worker.ts
@@ -175,9 +175,12 @@ async function runSimulationAsync(
     );
   }
 
-  // 6. Parse near-field if present
+  // 6. Parse near-field if requested
   let nearField: NearFieldResult | null = null;
-  nearField = parseNearFieldOutput(output, "horizontal", 1.8, 20.0, 0.5);
+  if (request.near_field) {
+    const nf = request.near_field;
+    nearField = parseNearFieldOutput(output, nf.plane, nf.height_m, nf.extent_m, nf.resolution_m);
+  }
 
   // 7. Compute total segments
   let totalSegments = 0;

--- a/frontend/src/pages/EditorPage.tsx
+++ b/frontend/src/pages/EditorPage.tsx
@@ -8,7 +8,7 @@
  *   [3D Viewport (45%)] [Bottom Sheet: Wires | Properties | Results]
  */
 
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { useEditorStore } from "../stores/editorStore";
 import { useSimulationStore } from "../stores/simulationStore";
 import { useUIStore } from "../stores/uiStore";
@@ -159,13 +159,9 @@ export function EditorPage() {
     return () => window.removeEventListener("keydown", handleKeyDown);
   }, [setMode, deselectAll, deleteSelected, undo, redo, selectAll]);
 
-  // Reset stale simulation results when antenna geometry or config changes
-  const isFirstRender = useRef(true);
+  // Clear stale results on page entry (prevents cross-page state leaks)
+  // and whenever antenna geometry or config changes.
   useEffect(() => {
-    if (isFirstRender.current) {
-      isFirstRender.current = false;
-      return;
-    }
     resetSimulation();
   }, [wires, excitations, loads, transmissionLines, ground, resetSimulation]);
 
@@ -186,6 +182,12 @@ export function EditorPage() {
       loads: loads.length > 0 ? loads : undefined,
       transmission_lines: transmissionLines.length > 0 ? transmissionLines : undefined,
       compute_currents: computeCurrents,
+      near_field: {
+        plane: "horizontal",
+        height_m: 1.8,
+        extent_m: 20.0,
+        resolution_m: 0.5,
+      },
       pattern_step: patternStep,
     });
   }, [wires, excitations, ground, frequencyRange, loads, transmissionLines, computeCurrents, patternStep, simulateAdvanced, getWireGeometry]);

--- a/frontend/src/pages/SimulatorPage.tsx
+++ b/frontend/src/pages/SimulatorPage.tsx
@@ -8,7 +8,7 @@
  *   [3D Viewport (45%)] [Bottom Sheet: Antenna | Results tabs]
  */
 
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { useAntennaStore } from "../stores/antennaStore";
 import { useSimulationStore } from "../stores/simulationStore";
 import { useUIStore } from "../stores/uiStore";
@@ -72,13 +72,9 @@ export function SimulatorPage() {
   const matching = useUIStore((s) => s.matching);
   const setMatching = useUIStore((s) => s.setMatching);
 
-  // Reset stale simulation results when antenna geometry or ground changes
-  const isFirstRender = useRef(true);
+  // Clear stale results on page entry (prevents cross-page state leaks)
+  // and whenever antenna geometry or ground changes.
   useEffect(() => {
-    if (isFirstRender.current) {
-      isFirstRender.current = false;
-      return;
-    }
     resetSimulation();
   }, [wireGeometry, ground, resetSimulation]);
 

--- a/frontend/src/stores/compareStore.ts
+++ b/frontend/src/stores/compareStore.ts
@@ -46,27 +46,28 @@ interface CompareState {
 
 let nextId = 1;
 
-export const useCompareStore = create<CompareState>((set, get) => ({
+export const useCompareStore = create<CompareState>((set) => ({
   savedResults: [],
   isComparing: false,
   maxResults: 6,
 
   saveResult: (result, label) => {
-    const { savedResults, maxResults } = get();
-    if (savedResults.length >= maxResults) {
-      // Remove oldest
-      set({ savedResults: savedResults.slice(1) });
-    }
     const id = `compare-${nextId++}`;
-    const colorIdx = savedResults.length % COMPARE_COLORS.length;
-    const saved: SavedResult = {
-      id,
-      label: label ?? `Run ${nextId - 1}`,
-      timestamp: Date.now(),
-      result,
-      color: COMPARE_COLORS[colorIdx]!,
-    };
-    set((s) => ({ savedResults: [...s.savedResults, saved] }));
+    set((s) => {
+      const trimmed =
+        s.savedResults.length >= s.maxResults
+          ? s.savedResults.slice(1)
+          : s.savedResults;
+      const colorIdx = trimmed.length % COMPARE_COLORS.length;
+      const saved: SavedResult = {
+        id,
+        label: label ?? `Run ${nextId - 1}`,
+        timestamp: Date.now(),
+        result,
+        color: COMPARE_COLORS[colorIdx]!,
+      };
+      return { savedResults: [...trimmed, saved] };
+    });
   },
 
   removeResult: (id) => {


### PR DESCRIPTION
## Summary
- **State leak between pages**: Remove `isFirstRender` guard so `resetSimulation()` fires on page mount — radiation pattern, currents, and near-field from the Simulator no longer persist when navigating to the Editor (and vice versa)
- **Near field broken in WASM mode**: Add `NearFieldConfig` type and NE card generation to the TS card deck builder. Both `simulate()` (template mode) and `simulateAdvanced()` (editor mode) now pass near-field config, matching the backend's behavior. The optimizer skips NE cards for performance.
- **Compare color bug**: Rewrite `compareStore.saveResult` to use a single atomic `set()` call — fixes color index being computed from stale pre-removal length when at max capacity (6 results)