### PR TITLE
fix(ui): comprehensive mobile layout overhaul

### DIFF
--- a/frontend/src/components/editors/BalunEditor.tsx
+++ b/frontend/src/components/editors/BalunEditor.tsx
@@ -98,7 +98,7 @@ export function BalunEditor({ matching, onChange }: BalunEditorProps) {
 
       {/* Show description for selected preset */}
       {!isCustom && currentPresetIndex >= 0 && (
-        <p className="text-[10px] text-text-secondary px-1 leading-tight">
+        <p className="text-[11px] text-text-secondary px-1 leading-tight">
           {MATCHING_PRESETS[currentPresetIndex]!.description}
         </p>
       )}
@@ -107,7 +107,7 @@ export function BalunEditor({ matching, onChange }: BalunEditorProps) {
       {isCustom && (
         <div className="space-y-1.5 px-1">
           <div className="flex items-center gap-2">
-            <label className="text-[10px] text-text-secondary w-10 shrink-0">
+            <label className="text-[11px] text-text-secondary w-10 shrink-0">
               Type:
             </label>
             <select
@@ -120,7 +120,7 @@ export function BalunEditor({ matching, onChange }: BalunEditorProps) {
             </select>
           </div>
           <div className="flex items-center gap-2">
-            <label className="text-[10px] text-text-secondary w-10 shrink-0">
+            <label className="text-[11px] text-text-secondary w-10 shrink-0">
               Ratio:
             </label>
             <div className="flex items-center gap-1 flex-1">
@@ -133,11 +133,11 @@ export function BalunEditor({ matching, onChange }: BalunEditorProps) {
                 step={0.1}
                 className="w-16 bg-background text-text-primary text-xs font-mono px-1.5 py-1 rounded border border-border outline-none"
               />
-              <span className="text-[10px] text-text-secondary">: 1</span>
+              <span className="text-[11px] text-text-secondary">: 1</span>
             </div>
           </div>
           <div className="flex items-center gap-2">
-            <label className="text-[10px] text-text-secondary w-10 shrink-0">
+            <label className="text-[11px] text-text-secondary w-10 shrink-0">
               Coax:
             </label>
             <select
@@ -149,7 +149,7 @@ export function BalunEditor({ matching, onChange }: BalunEditorProps) {
               <option value="75">75 &#937;</option>
             </select>
           </div>
-          <p className="text-[10px] text-text-secondary leading-tight">
+          <p className="text-[11px] text-text-secondary leading-tight">
             Z<sub>transformed</sub> = Z<sub>antenna</sub> / {matching.ratio} &rarr; SWR vs {matching.feedlineZ0}&#937;
           </p>
         </div>

--- a/frontend/src/components/editors/GroundEditor.tsx
+++ b/frontend/src/components/editors/GroundEditor.tsx
@@ -123,10 +123,10 @@ export function GroundEditor({ ground, onChange }: GroundEditorProps) {
                   text-sm font-mono text-text-primary focus:outline-none focus:ring-1
                   focus:ring-accent w-20"
               />
-              <span className="text-[10px] text-text-secondary">S/m</span>
+              <span className="text-[11px] text-text-secondary">S/m</span>
             </div>
           </div>
-          <p className="text-[10px] text-text-secondary leading-relaxed px-0.5">
+          <p className="text-[11px] text-text-secondary leading-relaxed px-0.5">
             Typical values: soil {"\u03B5"}r=3-20, {"\u03C3"}=0.0001-0.03.
             Water {"\u03B5"}r=80, concrete {"\u03B5"}r=4-8.
           </p>

--- a/frontend/src/components/editors/ImportExportPanel.tsx
+++ b/frontend/src/components/editors/ImportExportPanel.tsx
@@ -248,7 +248,7 @@ export function ImportExportPanel({ className = "" }: ImportExportPanelProps) {
       {/* Import */}
       <button
         onClick={handleImport}
-        className="w-full px-2 py-1.5 text-[10px] rounded border border-border text-text-secondary hover:text-text-primary hover:border-accent/50 transition-colors text-left"
+        className="w-full px-2 py-1.5 text-[11px] rounded border border-border text-text-secondary hover:text-text-primary hover:border-accent/50 transition-colors text-left"
       >
         Import .maa / .nec / .json
       </button>
@@ -258,28 +258,28 @@ export function ImportExportPanel({ className = "" }: ImportExportPanelProps) {
         <button
           onClick={handleExportJSON}
           disabled={wires.length === 0}
-          className="px-2 py-1 text-[10px] rounded border border-border text-text-secondary hover:text-text-primary hover:border-accent/50 transition-colors disabled:opacity-40"
+          className="px-2 py-1 text-[11px] rounded border border-border text-text-secondary hover:text-text-primary hover:border-accent/50 transition-colors disabled:opacity-40"
         >
           .json
         </button>
         <button
           onClick={handleExportNEC}
           disabled={wires.length === 0}
-          className="px-2 py-1 text-[10px] rounded border border-border text-text-secondary hover:text-text-primary hover:border-accent/50 transition-colors disabled:opacity-40"
+          className="px-2 py-1 text-[11px] rounded border border-border text-text-secondary hover:text-text-primary hover:border-accent/50 transition-colors disabled:opacity-40"
         >
           .nec
         </button>
         <button
           onClick={handleExportMAA}
           disabled={wires.length === 0}
-          className="px-2 py-1 text-[10px] rounded border border-border text-text-secondary hover:text-text-primary hover:border-accent/50 transition-colors disabled:opacity-40"
+          className="px-2 py-1 text-[11px] rounded border border-border text-text-secondary hover:text-text-primary hover:border-accent/50 transition-colors disabled:opacity-40"
         >
           .maa
         </button>
         <button
           onClick={handleExportCSV}
           disabled={!result}
-          className="px-2 py-1 text-[10px] rounded border border-border text-text-secondary hover:text-text-primary hover:border-accent/50 transition-colors disabled:opacity-40"
+          className="px-2 py-1 text-[11px] rounded border border-border text-text-secondary hover:text-text-primary hover:border-accent/50 transition-colors disabled:opacity-40"
         >
           .csv
         </button>
@@ -288,7 +288,7 @@ export function ImportExportPanel({ className = "" }: ImportExportPanelProps) {
       {/* Screenshot */}
       <button
         onClick={handleScreenshot}
-        className="w-full px-2 py-1 text-[10px] rounded border border-border text-text-secondary hover:text-text-primary hover:border-accent/50 transition-colors"
+        className="w-full px-2 py-1 text-[11px] rounded border border-border text-text-secondary hover:text-text-primary hover:border-accent/50 transition-colors"
       >
         Screenshot (.png)
       </button>

--- a/frontend/src/components/editors/TemplatePicker.tsx
+++ b/frontend/src/components/editors/TemplatePicker.tsx
@@ -66,11 +66,11 @@ export function TemplatePicker({ selectedId, onSelect }: TemplatePickerProps) {
               <div className="text-sm font-medium text-text-primary truncate">
                 {selectedTemplate.nameShort}
               </div>
-              <div className="text-[10px] text-text-secondary truncate">
+              <div className="text-[11px] text-text-secondary truncate">
                 {selectedTemplate.description}
               </div>
             </div>
-            <span className="text-[9px] text-text-secondary">Change</span>
+            <span className="text-[10px] text-text-secondary">Change</span>
           </div>
         </Card>
       )}
@@ -93,12 +93,12 @@ export function TemplatePicker({ selectedId, onSelect }: TemplatePickerProps) {
                   <div className="text-sm font-medium text-text-primary truncate">
                     {t.nameShort}
                   </div>
-                  <div className="text-[10px] text-text-secondary truncate">
+                  <div className="text-[11px] text-text-secondary truncate">
                     {t.description}
                   </div>
                 </div>
                 <span
-                  className={`text-[9px] uppercase font-medium ${difficultyColors[t.difficulty] ?? "text-text-secondary"}`}
+                  className={`text-[10px] uppercase font-medium ${difficultyColors[t.difficulty] ?? "text-text-secondary"}`}
                 >
                   {t.difficulty}
                 </span>

--- a/frontend/src/components/editors/WirePropertiesPanel.tsx
+++ b/frontend/src/components/editors/WirePropertiesPanel.tsx
@@ -24,7 +24,7 @@ function CoordField({
 }) {
   return (
     <div className="flex items-center gap-1">
-      <label className="text-[10px] text-text-secondary w-5 text-right shrink-0">
+      <label className="text-[11px] text-text-secondary w-5 text-right shrink-0">
         {label}
       </label>
       <input
@@ -35,7 +35,7 @@ function CoordField({
           const v = parseFloat(e.target.value);
           if (!isNaN(v) && isFinite(v)) onChange(v);
         }}
-        className="flex-1 bg-background text-text-primary text-[10px] font-mono px-1.5 py-0.5 rounded border border-border focus:border-accent/50 outline-none text-right"
+        className="flex-1 bg-background text-text-primary text-[11px] font-mono px-1.5 py-0.5 rounded border border-border focus:border-accent/50 outline-none text-right"
       />
     </div>
   );
@@ -87,7 +87,7 @@ export function WirePropertiesPanel() {
         <h4 className="text-xs font-medium text-text-secondary">
           {selectedWires.length} wires selected
         </h4>
-        <div className="text-[10px] text-text-secondary space-y-0.5 font-mono">
+        <div className="text-[11px] text-text-secondary space-y-0.5 font-mono">
           <div>Tags: {selectedWires.map((w) => w.tag).join(", ")}</div>
           <div>
             Total segments:{" "}
@@ -96,7 +96,7 @@ export function WirePropertiesPanel() {
         </div>
         <button
           onClick={() => deleteWires(selectedWires.map((w) => w.tag))}
-          className="w-full py-1 text-[10px] rounded bg-swr-bad/20 text-swr-bad hover:bg-swr-bad/30 transition-colors"
+          className="w-full py-1 text-[11px] rounded bg-swr-bad/20 text-swr-bad hover:bg-swr-bad/30 transition-colors"
         >
           Delete selected
         </button>
@@ -117,14 +117,14 @@ export function WirePropertiesPanel() {
         <h4 className="text-xs font-medium text-text-primary">
           Wire <span className="text-accent">{wire.tag}</span>
         </h4>
-        <span className="text-[10px] font-mono text-text-secondary">
+        <span className="text-[11px] font-mono text-text-secondary">
           {wire.segments} segs
         </span>
       </div>
 
       {/* Endpoint 1 */}
       <div className="space-y-1">
-        <div className="text-[10px] text-text-secondary font-medium">
+        <div className="text-[11px] text-text-secondary font-medium">
           Point 1
         </div>
         <CoordField
@@ -146,7 +146,7 @@ export function WirePropertiesPanel() {
 
       {/* Endpoint 2 */}
       <div className="space-y-1">
-        <div className="text-[10px] text-text-secondary font-medium">
+        <div className="text-[11px] text-text-secondary font-medium">
           Point 2
         </div>
         <CoordField
@@ -168,7 +168,7 @@ export function WirePropertiesPanel() {
 
       {/* Radius */}
       <div className="space-y-1">
-        <div className="text-[10px] text-text-secondary font-medium">
+        <div className="text-[11px] text-text-secondary font-medium">
           Radius
         </div>
         <div className="flex items-center gap-1">
@@ -182,14 +182,14 @@ export function WirePropertiesPanel() {
               const v = parseFloat(e.target.value);
               if (!isNaN(v)) handleRadiusChange(wire.tag, v);
             }}
-            className="flex-1 bg-background text-text-primary text-[10px] font-mono px-1.5 py-0.5 rounded border border-border focus:border-accent/50 outline-none text-right"
+            className="flex-1 bg-background text-text-primary text-[11px] font-mono px-1.5 py-0.5 rounded border border-border focus:border-accent/50 outline-none text-right"
           />
-          <span className="text-[10px] text-text-secondary">m</span>
+          <span className="text-[11px] text-text-secondary">m</span>
         </div>
       </div>
 
       {/* Wire length (computed) */}
-      <div className="text-[10px] font-mono text-text-secondary border-t border-border pt-2">
+      <div className="text-[11px] font-mono text-text-secondary border-t border-border pt-2">
         Length:{" "}
         {Math.sqrt(
           (wire.x2 - wire.x1) ** 2 +
@@ -201,14 +201,14 @@ export function WirePropertiesPanel() {
 
       {/* Excitation */}
       <div className="border-t border-border pt-2 space-y-1.5">
-        <div className="text-[10px] text-text-secondary font-medium">
+        <div className="text-[11px] text-text-secondary font-medium">
           Excitation
         </div>
         {hasExcitation ? (
           <>
             {/* Segment picker: number input + total */}
             <div className="flex items-center gap-1">
-              <span className="text-[10px] text-text-secondary">Seg</span>
+              <span className="text-[11px] text-text-secondary">Seg</span>
               <input
                 type="number"
                 min={1}
@@ -220,9 +220,9 @@ export function WirePropertiesPanel() {
                     setExcitation(wire.tag, v);
                   }
                 }}
-                className="w-12 bg-background text-text-primary text-[10px] font-mono px-1 py-0.5 rounded border border-border focus:border-accent/50 outline-none text-center"
+                className="w-12 bg-background text-text-primary text-[11px] font-mono px-1 py-0.5 rounded border border-border focus:border-accent/50 outline-none text-center"
               />
-              <span className="text-[10px] text-text-secondary font-mono">
+              <span className="text-[11px] text-text-secondary font-mono">
                 of {wire.segments}
               </span>
             </div>
@@ -231,7 +231,7 @@ export function WirePropertiesPanel() {
             <div className="flex gap-1">
               <button
                 onClick={() => setExcitation(wire.tag, 1)}
-                className={`flex-1 py-0.5 text-[10px] rounded transition-colors ${
+                className={`flex-1 py-0.5 text-[11px] rounded transition-colors ${
                   excitation.segment === 1
                     ? "bg-accent/20 text-accent"
                     : "bg-surface-hover text-text-secondary hover:text-text-primary"
@@ -243,7 +243,7 @@ export function WirePropertiesPanel() {
                 onClick={() =>
                   setExcitation(wire.tag, centerSegment(wire.segments))
                 }
-                className={`flex-1 py-0.5 text-[10px] rounded transition-colors ${
+                className={`flex-1 py-0.5 text-[11px] rounded transition-colors ${
                   excitation.segment === centerSegment(wire.segments)
                     ? "bg-accent/20 text-accent"
                     : "bg-surface-hover text-text-secondary hover:text-text-primary"
@@ -253,7 +253,7 @@ export function WirePropertiesPanel() {
               </button>
               <button
                 onClick={() => setExcitation(wire.tag, wire.segments)}
-                className={`flex-1 py-0.5 text-[10px] rounded transition-colors ${
+                className={`flex-1 py-0.5 text-[11px] rounded transition-colors ${
                   excitation.segment === wire.segments
                     ? "bg-accent/20 text-accent"
                     : "bg-surface-hover text-text-secondary hover:text-text-primary"
@@ -269,7 +269,7 @@ export function WirePropertiesPanel() {
                 onClick={() =>
                   setPickingExcitationForTag(isPicking ? null : wire.tag)
                 }
-                className={`flex-1 py-0.5 text-[10px] rounded transition-colors ${
+                className={`flex-1 py-0.5 text-[11px] rounded transition-colors ${
                   isPicking
                     ? "bg-swr-warning/30 text-swr-warning"
                     : "bg-swr-warning/10 text-swr-warning hover:bg-swr-warning/20"
@@ -282,7 +282,7 @@ export function WirePropertiesPanel() {
                   removeExcitation(wire.tag);
                   if (isPicking) setPickingExcitationForTag(null);
                 }}
-                className="flex-1 py-0.5 text-[10px] rounded bg-swr-bad/10 text-swr-bad hover:bg-swr-bad/20 transition-colors"
+                className="flex-1 py-0.5 text-[11px] rounded bg-swr-bad/10 text-swr-bad hover:bg-swr-bad/20 transition-colors"
               >
                 Remove
               </button>
@@ -296,13 +296,13 @@ export function WirePropertiesPanel() {
                 onChange={(e) => setAccurateFeedpoint(e.target.checked)}
                 className="accent-accent w-3 h-3"
               />
-              <span className="text-[10px] text-text-secondary">
+              <span className="text-[11px] text-text-secondary">
                 Accurate feedpoint
               </span>
-              <span className="text-[10px] text-text-secondary/50 cursor-help">
+              <span className="text-[11px] text-text-secondary/50 cursor-help">
                 ?
               </span>
-              <div className="absolute bottom-full left-0 mb-1 hidden group-hover/feedhelp:block bg-surface border border-border rounded-md px-2.5 py-1.5 shadow-lg text-[10px] text-text-secondary leading-relaxed w-52 z-50 pointer-events-none">
+              <div className="absolute bottom-full left-0 mb-1 hidden group-hover/feedhelp:block bg-surface border border-border rounded-md px-2.5 py-1.5 shadow-lg text-[11px] text-text-secondary leading-relaxed w-52 z-50 pointer-events-none">
                 NEC2 applies voltage at the segment center, not the wire
                 endpoint. When enabled, the marker shows the exact segment
                 center. When disabled, endpoint segments snap to the wire
@@ -316,7 +316,7 @@ export function WirePropertiesPanel() {
               onClick={() =>
                 setExcitation(wire.tag, centerSegment(wire.segments))
               }
-              className="w-full py-0.5 text-[10px] rounded bg-swr-warning/20 text-swr-warning hover:bg-swr-warning/30 transition-colors"
+              className="w-full py-0.5 text-[11px] rounded bg-swr-warning/20 text-swr-warning hover:bg-swr-warning/30 transition-colors"
             >
               Set as feedpoint
             </button>
@@ -325,7 +325,7 @@ export function WirePropertiesPanel() {
                 setExcitation(wire.tag, centerSegment(wire.segments));
                 setPickingExcitationForTag(wire.tag);
               }}
-              className="w-full py-0.5 text-[10px] rounded bg-swr-warning/10 text-swr-warning hover:bg-swr-warning/20 transition-colors"
+              className="w-full py-0.5 text-[11px] rounded bg-swr-warning/10 text-swr-warning hover:bg-swr-warning/20 transition-colors"
             >
               Pick on wire
             </button>
@@ -337,13 +337,13 @@ export function WirePropertiesPanel() {
       <div className="border-t border-border pt-2 flex gap-1">
         <button
           onClick={() => splitWire(wire.tag)}
-          className="flex-1 py-0.5 text-[10px] rounded bg-surface-hover text-text-secondary hover:text-text-primary transition-colors"
+          className="flex-1 py-0.5 text-[11px] rounded bg-surface-hover text-text-secondary hover:text-text-primary transition-colors"
         >
           Split
         </button>
         <button
           onClick={() => deleteWires([wire.tag])}
-          className="flex-1 py-0.5 text-[10px] rounded bg-swr-bad/20 text-swr-bad hover:bg-swr-bad/30 transition-colors"
+          className="flex-1 py-0.5 text-[11px] rounded bg-swr-bad/20 text-swr-bad hover:bg-swr-bad/30 transition-colors"
         >
           Delete
         </button>

--- a/frontend/src/components/editors/WireTable.tsx
+++ b/frontend/src/components/editors/WireTable.tsx
@@ -1,15 +1,16 @@
 /**
  * WireTable — V2 spreadsheet-style wire list for the wire editor.
  *
- * Displays all wires with editable coordinates, segments, and radius.
- * Clicking a row selects the wire in the 3D viewport.
+ * Desktop: spreadsheet table with editable coordinates, segments, and radius.
+ * Mobile: card-based layout for each wire with tap-to-edit.
+ * Clicking a row/card selects the wire in the 3D viewport.
  */
 
 import { useCallback, useState, useRef, useEffect } from "react";
 import { useEditorStore } from "../../stores/editorStore";
 import type { EditorWire } from "../../stores/editorStore";
 
-/** Column definitions */
+/** Column definitions (used by desktop table) */
 const COLUMNS = [
   { key: "tag", label: "Tag", width: "w-12", editable: false },
   { key: "segments", label: "Segs", width: "w-12", editable: false },
@@ -57,6 +58,15 @@ export function WireTable() {
   );
 
   const handleCellDoubleClick = useCallback(
+    (tag: number, field: EditableKey, currentValue: number) => {
+      setEditCell({ tag, field });
+      setEditValue(String(currentValue));
+    },
+    []
+  );
+
+  // Tap-to-edit for mobile cards
+  const handleCellTap = useCallback(
     (tag: number, field: EditableKey, currentValue: number) => {
       setEditCell({ tag, field });
       setEditValue(String(currentValue));
@@ -113,33 +123,78 @@ export function WireTable() {
     return v.toFixed(decimals);
   };
 
+  // Shared header bar
+  const headerBar = (
+    <div className="flex items-center justify-between px-2 py-1.5 border-b border-border">
+      <h3 className="text-xs font-medium text-text-secondary uppercase tracking-wider">
+        Wires ({wires.length})
+      </h3>
+      <div className="flex items-center gap-1.5">
+        {selectedTags.size > 0 && (
+          <button
+            onClick={handleDeleteSelected}
+            className="px-2 py-1 text-[11px] rounded bg-swr-bad/20 text-swr-bad hover:bg-swr-bad/30 transition-colors"
+            title="Delete selected wires"
+          >
+            Del
+          </button>
+        )}
+        <button
+          onClick={handleAddWire}
+          className="px-2 py-1 text-[11px] rounded bg-accent/20 text-accent hover:bg-accent/30 transition-colors"
+          title="Add new wire"
+        >
+          + Wire
+        </button>
+      </div>
+    </div>
+  );
+
+  // Empty state
+  const emptyState = (
+    <div className="flex items-center justify-center py-8 text-text-secondary text-xs">
+      No wires. Click &quot;+ Wire&quot; to add one.
+    </div>
+  );
+
+  // Editable cell inline input for mobile cards
+  const renderEditableValue = (
+    wire: EditorWire,
+    field: EditableKey,
+    decimals: number,
+  ) => {
+    const isEditing = editCell?.tag === wire.tag && editCell?.field === field;
+    const value = wire[field] as number;
+    if (isEditing) {
+      return (
+        <input
+          ref={inputRef}
+          type="text"
+          inputMode="decimal"
+          value={editValue}
+          onChange={(e) => setEditValue(e.target.value)}
+          onBlur={commitEdit}
+          onKeyDown={handleKeyDown}
+          className="w-full bg-accent/20 text-text-primary text-right text-xs font-mono px-1 py-0.5 rounded outline-none border border-accent/40"
+        />
+      );
+    }
+    return (
+      <button
+        onClick={() => handleCellTap(wire.tag, field, value)}
+        className="w-full text-right text-xs font-mono text-text-primary px-1 py-0.5 rounded hover:bg-surface-hover transition-colors"
+      >
+        {formatNum(value, decimals)}
+      </button>
+    );
+  };
+
   return (
     <div className="flex flex-col h-full">
-      <div className="flex items-center justify-between px-2 py-1.5 border-b border-border">
-        <h3 className="text-xs font-medium text-text-secondary uppercase tracking-wider">
-          Wires ({wires.length})
-        </h3>
-        <div className="flex items-center gap-1">
-          {selectedTags.size > 0 && (
-            <button
-              onClick={handleDeleteSelected}
-              className="px-1.5 py-0.5 text-[10px] rounded bg-swr-bad/20 text-swr-bad hover:bg-swr-bad/30 transition-colors"
-              title="Delete selected wires"
-            >
-              Del
-            </button>
-          )}
-          <button
-            onClick={handleAddWire}
-            className="px-1.5 py-0.5 text-[10px] rounded bg-accent/20 text-accent hover:bg-accent/30 transition-colors"
-            title="Add new wire"
-          >
-            + Wire
-          </button>
-        </div>
-      </div>
+      {headerBar}
 
-      <div className="flex-1 overflow-auto">
+      {/* === Desktop table (lg and up) === */}
+      <div className="hidden lg:block flex-1 overflow-auto">
         <table className="w-full text-[10px] font-mono">
           <thead className="sticky top-0 bg-surface z-10">
             <tr>
@@ -223,12 +278,48 @@ export function WireTable() {
             })}
           </tbody>
         </table>
+        {wires.length === 0 && emptyState}
+      </div>
 
-        {wires.length === 0 && (
-          <div className="flex items-center justify-center py-8 text-text-secondary text-xs">
-            No wires. Click "+ Wire" to add one.
-          </div>
-        )}
+      {/* === Mobile card layout (below lg) === */}
+      <div className="lg:hidden flex-1 overflow-y-auto space-y-1.5 p-1.5">
+        {wires.map((wire) => {
+          const isSelected = selectedTags.has(wire.tag);
+          return (
+            <div
+              key={wire.tag}
+              onClick={(e) => handleRowClick(wire.tag, e)}
+              className={`rounded-md border p-2 transition-colors cursor-pointer ${
+                isSelected
+                  ? "border-accent/40 bg-accent/10"
+                  : "border-border bg-background hover:bg-surface-hover"
+              }`}
+            >
+              {/* Card header */}
+              <div className="flex items-center justify-between mb-1.5">
+                <span className="text-xs font-bold text-accent">Wire {wire.tag}</span>
+                <span className="text-[11px] text-text-secondary font-mono">
+                  {wire.segments} segs | R={formatNum(wire.radius, 4)}m
+                </span>
+              </div>
+              {/* Coordinates grid */}
+              <div className="grid grid-cols-6 gap-0.5 text-center">
+                <span className="text-[10px] text-text-secondary">X1</span>
+                <span className="text-[10px] text-text-secondary">Y1</span>
+                <span className="text-[10px] text-text-secondary">Z1</span>
+                <span className="text-[10px] text-text-secondary">X2</span>
+                <span className="text-[10px] text-text-secondary">Y2</span>
+                <span className="text-[10px] text-text-secondary">Z2</span>
+                {(["x1", "y1", "z1", "x2", "y2", "z2"] as const).map((f) => (
+                  <div key={f} onClick={(e) => e.stopPropagation()}>
+                    {renderEditableValue(wire, f, 2)}
+                  </div>
+                ))}
+              </div>
+            </div>
+          );
+        })}
+        {wires.length === 0 && emptyState}
       </div>
     </div>
   );

--- a/frontend/src/components/layout/Navbar.tsx
+++ b/frontend/src/components/layout/Navbar.tsx
@@ -1,10 +1,22 @@
 /**
  * Top navigation bar — logo, nav links, theme toggle, unit toggle.
+ *
+ * Mobile: hamburger menu toggles a dropdown panel with all nav links.
+ * Desktop: links shown inline in the header.
  */
 
-import { useCallback } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { Link, useLocation } from "react-router-dom";
 import { useUIStore } from "../../stores/uiStore";
+
+/** Shared nav link definitions */
+const NAV_LINKS = [
+  { to: "/", label: "Simulator" },
+  { to: "/editor", label: "Editor" },
+  { to: "/library", label: "Library" },
+  { to: "/learn", label: "Learn" },
+  { to: "/about", label: "About" },
+] as const;
 
 export function Navbar() {
   const theme = useUIStore((s) => s.theme);
@@ -22,118 +34,159 @@ export function Navbar() {
     toggleUnits();
   }, [toggleUnits]);
 
+  // Mobile menu state
+  const [menuOpen, setMenuOpen] = useState(false);
+  const menuRef = useRef<HTMLDivElement>(null);
+
+  // Close menu on route change
+  useEffect(() => {
+    setMenuOpen(false);
+  }, [location.pathname]);
+
+  // Close menu on outside click
+  useEffect(() => {
+    if (!menuOpen) return;
+    const handleOutside = (e: PointerEvent) => {
+      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
+        setMenuOpen(false);
+      }
+    };
+    document.addEventListener("pointerdown", handleOutside);
+    return () => document.removeEventListener("pointerdown", handleOutside);
+  }, [menuOpen]);
+
+  function linkClass(path: string): string {
+    const active = location.pathname === path;
+    return `hover:text-accent transition-colors ${
+      active ? "text-accent font-medium" : "text-text-secondary"
+    }`;
+  }
+
   return (
-    <header className="flex items-center justify-between px-4 h-11 border-b border-border bg-surface shrink-0">
-      <div className="flex items-center gap-6">
-        {/* Logo */}
-        <Link to="/" className="flex items-center gap-2">
-          <span className="text-accent font-bold text-lg tracking-tight">
-            AntennaSim
-          </span>
-          <span className="text-text-secondary text-[10px] font-mono">
-            v{__APP_VERSION__}
-          </span>
-        </Link>
+    <header className="relative shrink-0">
+      <div className="flex items-center justify-between px-4 h-11 border-b border-border bg-surface">
+        <div className="flex items-center gap-6">
+          {/* Logo */}
+          <Link to="/" className="flex items-center gap-2">
+            <span className="text-accent font-bold text-lg tracking-tight">
+              AntennaSim
+            </span>
+            <span className="text-text-secondary text-[10px] font-mono">
+              v{__APP_VERSION__}
+            </span>
+          </Link>
 
-        {/* Nav links */}
-        <nav className="hidden md:flex items-center gap-4 text-sm">
-          <Link
-            to="/"
-            className={`hover:text-accent transition-colors ${
-              location.pathname === "/"
-                ? "text-text-primary font-medium"
-                : "text-text-secondary"
-            }`}
-          >
-            Simulator
-          </Link>
-          <Link
-            to="/editor"
-            className={`hover:text-accent transition-colors ${
-              location.pathname === "/editor"
-                ? "text-accent font-medium"
-                : "text-text-secondary"
-            }`}
-          >
-            Editor
-          </Link>
-          <Link
-            to="/library"
-            className={`hover:text-accent transition-colors ${
-              location.pathname === "/library"
-                ? "text-text-primary font-medium"
-                : "text-text-secondary"
-            }`}
-          >
-            Library
-          </Link>
-          <Link
-            to="/learn"
-            className={`hover:text-accent transition-colors ${
-              location.pathname === "/learn"
-                ? "text-text-primary font-medium"
-                : "text-text-secondary"
-            }`}
-          >
-            Learn
-          </Link>
-          <Link
-            to="/about"
-            className={`hover:text-accent transition-colors ${
-              location.pathname === "/about"
-                ? "text-text-primary font-medium"
-                : "text-text-secondary"
-            }`}
-          >
-            About
-          </Link>
-        </nav>
-      </div>
+          {/* Desktop nav links */}
+          <nav className="hidden md:flex items-center gap-4 text-sm">
+            {NAV_LINKS.map(({ to, label }) => (
+              <Link key={to} to={to} className={linkClass(to)}>
+                {label}
+              </Link>
+            ))}
+          </nav>
+        </div>
 
-      <div className="flex items-center gap-2">
-        {/* Unit toggle */}
-        <button
-          onClick={handleUnitToggle}
-          className="px-1.5 py-0.5 rounded-md text-[11px] font-mono text-text-secondary
-            hover:text-text-primary hover:bg-surface-hover transition-colors border border-border"
-          title={`Switch to ${imperial ? "metric" : "imperial"} units`}
-        >
-          {imperial ? "ft" : "m"}
-        </button>
+        <div className="flex items-center gap-2">
+          {/* Unit toggle */}
+          <button
+            onClick={handleUnitToggle}
+            className="px-1.5 py-0.5 rounded-md text-[11px] font-mono text-text-secondary
+              hover:text-text-primary hover:bg-surface-hover transition-colors border border-border"
+            title={`Switch to ${imperial ? "metric" : "imperial"} units`}
+          >
+            {imperial ? "ft" : "m"}
+          </button>
 
-        {/* Theme toggle */}
-        <button
-          onClick={handleThemeToggle}
-          className="p-1.5 rounded-md text-text-secondary hover:text-text-primary
-            hover:bg-surface-hover transition-colors"
-          title={`Switch to ${theme === "dark" ? "light" : "dark"} theme`}
-        >
-          {theme === "dark" ? (
+          {/* Theme toggle */}
+          <button
+            onClick={handleThemeToggle}
+            className="p-1.5 rounded-md text-text-secondary hover:text-text-primary
+              hover:bg-surface-hover transition-colors"
+            title={`Switch to ${theme === "dark" ? "light" : "dark"} theme`}
+          >
+            {theme === "dark" ? (
+              <svg
+                width="16"
+                height="16"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+              >
+                <circle cx="12" cy="12" r="5" />
+                <path d="M12 1v2M12 21v2M4.22 4.22l1.42 1.42M18.36 18.36l1.42 1.42M1 12h2M21 12h2M4.22 19.78l1.42-1.42M18.36 5.64l1.42-1.42" />
+              </svg>
+            ) : (
+              <svg
+                width="16"
+                height="16"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+              >
+                <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
+              </svg>
+            )}
+          </button>
+
+          {/* Hamburger button (mobile only) */}
+          <button
+            onClick={() => setMenuOpen((o) => !o)}
+            className="md:hidden p-2 -mr-2 rounded-md text-text-secondary hover:text-text-primary
+              hover:bg-surface-hover transition-colors"
+            aria-label="Toggle navigation menu"
+            aria-expanded={menuOpen}
+          >
             <svg
-              width="16"
-              height="16"
+              width="18"
+              height="18"
               viewBox="0 0 24 24"
               fill="none"
               stroke="currentColor"
               strokeWidth="2"
+              strokeLinecap="round"
             >
-              <circle cx="12" cy="12" r="5" />
-              <path d="M12 1v2M12 21v2M4.22 4.22l1.42 1.42M18.36 18.36l1.42 1.42M1 12h2M21 12h2M4.22 19.78l1.42-1.42M18.36 5.64l1.42-1.42" />
+              {menuOpen ? (
+                <>
+                  <line x1="18" y1="6" x2="6" y2="18" />
+                  <line x1="6" y1="6" x2="18" y2="18" />
+                </>
+              ) : (
+                <>
+                  <line x1="3" y1="6" x2="21" y2="6" />
+                  <line x1="3" y1="12" x2="21" y2="12" />
+                  <line x1="3" y1="18" x2="21" y2="18" />
+                </>
+              )}
             </svg>
-          ) : (
-            <svg
-              width="16"
-              height="16"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="2"
-            >
-              <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
-            </svg>
-          )}
-        </button>
+          </button>
+        </div>
       </div>
+
+      {/* Mobile dropdown menu */}
+      {menuOpen && (
+        <div
+          ref={menuRef}
+          className="md:hidden absolute top-full left-0 right-0 z-50 border-b border-border bg-surface shadow-lg"
+        >
+          <nav className="flex flex-col py-2">
+            {NAV_LINKS.map(({ to, label }) => (
+              <Link
+                key={to}
+                to={to}
+                className={`px-6 py-3 text-sm transition-colors ${
+                  location.pathname === to
+                    ? "text-accent font-medium bg-accent/5"
+                    : "text-text-secondary hover:text-text-primary hover:bg-surface-hover"
+                }`}
+              >
+                {label}
+              </Link>
+            ))}
+          </nav>
+        </div>
+      )}
     </header>
   );
 }

--- a/frontend/src/components/three/CameraControls.tsx
+++ b/frontend/src/components/three/CameraControls.tsx
@@ -1,9 +1,13 @@
 /**
- * Camera orbit controls with smooth damping and auto-framing.
+ * Camera orbit controls with smooth damping, auto-framing, and follow mode.
  *
  * Auto-framing: computes bounding box of antenna wires and positions camera
  * to show the complete antenna with ground context. Triggers on template
  * change (wire count change), not on slider tweaks.
+ *
+ * Follow mode: when wires move without count changing (e.g., height slider),
+ * the camera and orbit target shift by the same delta to track the antenna.
+ * Uses smooth lerp interpolation so the transition feels natural.
  *
  * Camera view presets are handled by the GizmoViewport in AxesHelper.tsx.
  */
@@ -84,36 +88,70 @@ export function CameraControls({ enabled = true, wires = [], hasGround = true }:
   // Track previous wire count to detect template changes (init to 0 so first mount triggers auto-frame)
   const prevWireCountRef = useRef(0);
 
-  // Auto-frame when wires change significantly (template change) — only when wire count changes
+  // Track previous wire centroid (ignoring ground/padding) for follow-mode delta
+  const prevCentroidRef = useRef<Vector3 | null>(null);
+
+  // Compute the raw centroid of wire endpoints in Three.js coords (no ground, no padding)
+  const wireCentroid = useMemo(() => {
+    if (wires.length === 0) return new Vector3();
+    const sum = new Vector3();
+    let count = 0;
+    for (const w of wires) {
+      // NEC2 → Three.js: [necX, necZ, -necY]
+      sum.add(new Vector3(w.x1, w.z1, -w.y1));
+      sum.add(new Vector3(w.x2, w.z2, -w.y2));
+      count += 2;
+    }
+    return sum.divideScalar(count);
+  }, [wires]);
+
+  // Auto-frame when wires change significantly (template change) — only when wire count changes.
+  // Follow mode: when wires move without count changing (height slider, drag), apply the
+  // position delta instantly so the camera keeps pace with the antenna.
   useEffect(() => {
-    if (wires.length === prevWireCountRef.current) return;
-    prevWireCountRef.current = wires.length;
+    if (wires.length !== prevWireCountRef.current) {
+      // Wire count changed — full auto-frame
+      prevWireCountRef.current = wires.length;
+      prevCentroidRef.current = wireCentroid.clone();
 
-    if (wires.length === 0 || !controlsRef.current) return;
+      if (wires.length === 0 || !controlsRef.current) return;
 
-    const center = new Vector3();
-    const size = new Vector3();
-    bbox.getCenter(center);
-    bbox.getSize(size);
-    const diagonal = size.length();
+      const center = new Vector3();
+      const size = new Vector3();
+      bbox.getCenter(center);
+      bbox.getSize(size);
+      const diagonal = size.length();
 
-    // Position camera at 1.5x diagonal distance, isometric-ish angle
-    const dist = Math.max(diagonal * 1.5, 5);
-    const endPos = new Vector3(
-      center.x + dist * 0.6,
-      center.y + dist * 0.5,
-      center.z + dist * 0.6
-    );
+      // Position camera at 1.5x diagonal distance, isometric-ish angle
+      const dist = Math.max(diagonal * 1.5, 5);
+      const endPos = new Vector3(
+        center.x + dist * 0.6,
+        center.y + dist * 0.5,
+        center.z + dist * 0.6
+      );
 
-    animRef.current = {
-      active: true,
-      startPos: camera.position.clone(),
-      endPos,
-      startTarget: controlsRef.current.target.clone(),
-      endTarget: center,
-      progress: 0,
-    };
-  }, [bbox, wires.length, camera]);
+      animRef.current = {
+        active: true,
+        startPos: camera.position.clone(),
+        endPos,
+        startTarget: controlsRef.current.target.clone(),
+        endTarget: center,
+        progress: 0,
+      };
+    } else if (wires.length > 0 && prevCentroidRef.current && controlsRef.current) {
+      // Wire count unchanged but wires moved (height change, etc.) — instant follow.
+      // Use raw wire centroid (not bbox center) so ground plane doesn't dilute the delta.
+      const delta = wireCentroid.clone().sub(prevCentroidRef.current);
+      if (delta.lengthSq() > 0.0001) {
+        camera.position.add(delta);
+        controlsRef.current.target.add(delta);
+        controlsRef.current.update();
+        prevCentroidRef.current = wireCentroid.clone();
+      }
+    } else {
+      prevCentroidRef.current = wireCentroid.clone();
+    }
+  }, [bbox, wires.length, wireCentroid, camera]);
 
   // Animate camera each frame (auto-framing only)
   useFrame((_, delta) => {

--- a/frontend/src/components/three/EditorScene.tsx
+++ b/frontend/src/components/three/EditorScene.tsx
@@ -493,6 +493,7 @@ export function EditorScene({ viewToggles, patternData, currents, nearField }: E
   const glConfig = useMemo(
     () => ({
       antialias: true,
+      preserveDrawingBuffer: true,
       toneMapping: ACESFilmicToneMapping,
       outputColorSpace: SRGBColorSpace,
       toneMappingExposure: 1.0,

--- a/frontend/src/components/three/SceneRoot.tsx
+++ b/frontend/src/components/three/SceneRoot.tsx
@@ -53,6 +53,7 @@ export function SceneRoot({
   const glConfig = useMemo(
     () => ({
       antialias: true,
+      preserveDrawingBuffer: true,
       toneMapping: ACESFilmicToneMapping,
       outputColorSpace: SRGBColorSpace,
       toneMappingExposure: 1.0,

--- a/frontend/src/components/three/ViewToggleToolbar.tsx
+++ b/frontend/src/components/three/ViewToggleToolbar.tsx
@@ -87,7 +87,7 @@ export function ViewToggleToolbar({ toggles, onToggle }: ViewToggleToolbarProps)
         <div className="absolute bottom-full left-0 mb-1 bg-surface/95 backdrop-blur-md border border-border rounded-lg shadow-lg p-2.5 min-w-[200px]">
           {GROUPS.map((group, gi) => (
             <div key={group.label} className={gi > 0 ? "mt-2 pt-2 border-t border-border/50" : ""}>
-              <div className="text-[9px] font-semibold text-text-secondary uppercase tracking-wider mb-1.5 px-0.5">
+              <div className="text-[10px] font-semibold text-text-secondary uppercase tracking-wider mb-1.5 px-0.5">
                 {group.label}
               </div>
               <div className="flex flex-wrap gap-1">
@@ -95,7 +95,7 @@ export function ViewToggleToolbar({ toggles, onToggle }: ViewToggleToolbarProps)
                   <button
                     key={key}
                     onClick={() => onToggle(key)}
-                    className={`px-2 py-1 text-xs rounded transition-colors ${
+                    className={`px-2.5 py-1.5 text-xs rounded transition-colors ${
                       toggles[key]
                         ? "bg-accent/20 text-accent border-accent/50"
                         : "bg-background/60 text-text-secondary border-border/50 hover:bg-background hover:text-text-primary"

--- a/frontend/src/components/ui/Button.tsx
+++ b/frontend/src/components/ui/Button.tsx
@@ -25,9 +25,9 @@ const variantClasses: Record<ButtonVariant, string> = {
 };
 
 const sizeClasses: Record<ButtonSize, string> = {
-  sm: "px-2.5 py-1 text-xs",
+  sm: "px-3 py-1.5 text-xs",
   md: "px-4 py-2 text-sm",
-  lg: "px-6 py-2.5 text-base",
+  lg: "px-6 py-3 text-base",
 };
 
 export function Button({

--- a/frontend/src/components/ui/SegmentedControl.tsx
+++ b/frontend/src/components/ui/SegmentedControl.tsx
@@ -32,7 +32,7 @@ export function SegmentedControl({
           key={seg.key}
           onClick={handleClick(seg.key)}
           className={`
-            flex-1 px-3 py-1.5 text-xs font-medium rounded-md transition-colors
+            flex-1 px-2 py-2 text-xs font-medium rounded-md transition-colors
             ${
               activeKey === seg.key
                 ? "bg-surface text-text-primary shadow-sm"

--- a/frontend/src/components/ui/Slider.tsx
+++ b/frontend/src/components/ui/Slider.tsx
@@ -145,17 +145,18 @@ export function Slider({
         step={step}
         value={localValue}
         onChange={handleSliderChange}
-        className="w-full h-1.5 bg-border rounded-full appearance-none cursor-pointer
+        className="w-full h-2 bg-border rounded-full appearance-none cursor-pointer
           [&::-webkit-slider-thumb]:appearance-none
-          [&::-webkit-slider-thumb]:w-3.5
-          [&::-webkit-slider-thumb]:h-3.5
+          [&::-webkit-slider-thumb]:w-5
+          [&::-webkit-slider-thumb]:h-5
           [&::-webkit-slider-thumb]:rounded-full
           [&::-webkit-slider-thumb]:bg-accent
           [&::-webkit-slider-thumb]:hover:bg-accent-hover
           [&::-webkit-slider-thumb]:transition-colors
           [&::-webkit-slider-thumb]:cursor-pointer
-          [&::-moz-range-thumb]:w-3.5
-          [&::-moz-range-thumb]:h-3.5
+          [&::-webkit-slider-thumb]:shadow-md
+          [&::-moz-range-thumb]:w-5
+          [&::-moz-range-thumb]:h-5
           [&::-moz-range-thumb]:rounded-full
           [&::-moz-range-thumb]:bg-accent
           [&::-moz-range-thumb]:border-0
@@ -163,7 +164,7 @@ export function Slider({
           [&::-moz-range-thumb]:cursor-pointer
           [&::-moz-range-track]:bg-border
           [&::-moz-range-track]:rounded-full
-          [&::-moz-range-track]:h-1.5"
+          [&::-moz-range-track]:h-2"
       />
     </div>
   );

--- a/frontend/src/pages/EditorPage.tsx
+++ b/frontend/src/pages/EditorPage.tsx
@@ -30,6 +30,7 @@ import { ImportExportPanel } from "../components/editors/ImportExportPanel";
 import { OptimizerPanel } from "../components/editors/OptimizerPanel";
 import { ColorScale } from "../components/ui/ColorScale";
 import { Button } from "../components/ui/Button";
+import { Slider } from "../components/ui/Slider";
 import { SegmentedControl } from "../components/ui/SegmentedControl";
 import { templates } from "../templates";
 import { getDefaultParams } from "../templates/types";
@@ -40,10 +41,12 @@ import type { ViewToggles } from "../components/three/types";
 const MOBILE_SEGMENTS = [
   { key: "wires", label: "Wires" },
   { key: "properties", label: "Props" },
+  { key: "settings", label: "Settings" },
+  { key: "tools", label: "Tools" },
   { key: "results", label: "Results" },
 ];
 
-type MobileEditorTab = "wires" | "properties" | "results";
+type MobileEditorTab = "wires" | "properties" | "settings" | "tools" | "results";
 
 export function EditorPage() {
   // Editor store
@@ -120,6 +123,7 @@ export function EditorPage() {
   useEffect(() => {
     if (simStatus === "success") {
       setRightPanelTab("results");
+      setMobileTab("results");
     }
   }, [simStatus]);
 
@@ -281,7 +285,7 @@ export function EditorPage() {
         </div>
 
         {/* === CENTER: 3D VIEWPORT === */}
-        <main className="flex-1 relative min-w-0">
+        <main className="flex-1 relative min-w-0 min-h-[35vh]">
           <ErrorBoundary label="3D Viewport">
             <EditorScene viewToggles={viewToggles} patternData={patternData} currents={currentData} nearField={nearFieldData} />
           </ErrorBoundary>
@@ -316,18 +320,30 @@ export function EditorPage() {
 
           {/* Pattern frequency slider */}
           {simStatus === "success" && simResult && simResult.frequency_data.length > 1 && (
-            <div className="absolute bottom-2 left-1/2 -translate-x-1/2 z-10 w-56 hidden lg:block">
+            <div className="absolute bottom-2 left-1/2 -translate-x-1/2 z-10 w-44 lg:w-56">
               <PatternFrequencySlider />
             </div>
           )}
 
-          {/* Mobile toolbar (floating) */}
-          <div className="lg:hidden absolute top-2 right-14 z-10 flex gap-1">
+          {/* Empty-state hint */}
+          {wires.length === 0 && (
+            <div className="absolute inset-0 flex items-center justify-center z-10 pointer-events-none">
+              <div className="bg-surface/90 backdrop-blur-sm border border-border rounded-lg px-4 py-3 max-w-[240px] text-center pointer-events-auto">
+                <p className="text-sm text-text-primary font-medium mb-1">No wires yet</p>
+                <p className="text-xs text-text-secondary leading-relaxed">
+                  Switch to <span className="text-accent font-medium">Add</span> mode and click the viewport to place wires, or go to <span className="text-accent font-medium">Tools</span> to import a file or load a template.
+                </p>
+              </div>
+            </div>
+          )}
+
+          {/* Mobile toolbar (floating, below mode indicator) */}
+          <div className="lg:hidden absolute top-10 left-2 z-10 flex gap-1">
             {(["select", "add", "move"] as const).map((m) => (
               <button
                 key={m}
                 onClick={() => setMode(m)}
-                className={`px-2 py-1 text-[10px] rounded-md font-mono ${
+                className={`px-3 py-2 text-xs rounded-md font-mono ${
                   mode === m
                     ? "bg-accent/20 text-accent border border-accent/40"
                     : "bg-surface/80 text-text-secondary border border-border"
@@ -465,40 +481,6 @@ export function EditorPage() {
                 {/* === Settings section: height, snap, ground, balun, pattern res === */}
                 {editorSection === "settings" && (
                   <div className="px-2 py-2 space-y-3">
-                    {/* Antenna height */}
-                    {wires.length > 0 && (
-                      <div>
-                        <label className="text-[10px] text-text-secondary font-semibold uppercase tracking-wider block mb-1">
-                          Antenna Height
-                        </label>
-                        <div className="flex items-center gap-2">
-                          <input
-                            type="range"
-                            min="0"
-                            max="100"
-                            step="0.5"
-                            value={antennaMinZ}
-                            onChange={(e) => handleHeightChange(parseFloat(e.target.value))}
-                            className="flex-1 h-1 accent-accent"
-                            title={`Lowest point: ${antennaMinZ}m, Highest: ${antennaMaxZ}m`}
-                          />
-                          <input
-                            type="number"
-                            step="0.5"
-                            min="0"
-                            max="200"
-                            value={antennaMinZ}
-                            onChange={(e) => {
-                              const v = parseFloat(e.target.value);
-                              if (!isNaN(v) && v >= 0) handleHeightChange(v);
-                            }}
-                            className="w-14 bg-background text-text-primary text-[10px] font-mono px-1 py-0.5 rounded border border-border focus:border-accent/50 outline-none text-right"
-                          />
-                          <span className="text-[10px] text-text-secondary">m</span>
-                        </div>
-                      </div>
-                    )}
-
                     {/* Snap size */}
                     <div>
                       <label className="text-[10px] text-text-secondary font-semibold uppercase tracking-wider block mb-1">
@@ -628,6 +610,21 @@ export function EditorPage() {
               <span className="text-[10px] text-text-secondary">pts</span>
             </div>
 
+            {/* Antenna height */}
+            {wires.length > 0 && (
+              <Slider
+                label="Antenna Height"
+                value={antennaMinZ}
+                min={0}
+                max={100}
+                step={0.5}
+                unit="m"
+                decimals={1}
+                description={`Lowest point: ${antennaMinZ}m, Highest: ${antennaMaxZ}m`}
+                onChange={handleHeightChange}
+              />
+            )}
+
             {/* Warning: wires at ground level */}
             {allWiresAtGround && (
               <div className="flex items-start gap-1.5 p-1.5 rounded-md bg-swr-warning/10 border border-swr-warning/30">
@@ -637,7 +634,7 @@ export function EditorPage() {
                   <line x1="12" y1="17" x2="12.01" y2="17" />
                 </svg>
                 <p className="text-[10px] text-swr-warning leading-tight">
-                  All wires are at ground level (Z=0). Go to Settings to raise the antenna, or results will show no radiation.
+                  All wires are at ground level (Z=0). Use the height slider above to raise the antenna, or results will show no radiation.
                 </p>
               </div>
             )}
@@ -661,41 +658,191 @@ export function EditorPage() {
 
       {/* === MOBILE BOTTOM SHEET === */}
       <div className="lg:hidden border-t border-border bg-surface flex flex-col max-h-[55vh]">
-        <div className="flex justify-center py-1.5 shrink-0">
-          <div className="w-8 h-1 rounded-full bg-border" />
+        {/* Tab bar + Run button + quick actions */}
+        <div className="px-2 pt-2 pb-1 shrink-0 space-y-1.5">
+          <div className="flex items-center gap-2">
+            <div className="flex-1 overflow-x-auto">
+              <SegmentedControl
+                segments={MOBILE_SEGMENTS}
+                activeKey={mobileTab}
+                onChange={(key) => setMobileTab(key as MobileEditorTab)}
+              />
+            </div>
+            <Button
+              onClick={handleRunSimulation}
+              loading={isLoading}
+              disabled={isLoading || !canRun}
+              size="sm"
+              className="shrink-0"
+            >
+              {isLoading ? "..." : "Run"}
+            </Button>
+          </div>
+          {/* Quick operations bar */}
+          <div className="flex items-center gap-1">
+            <button onClick={undo} className="px-2 py-1 text-[11px] rounded border border-border text-text-secondary hover:bg-surface-hover" title="Undo">
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><path d="M3 10h13a4 4 0 010 8H7" /><path d="M3 10l4-4M3 10l4 4" /></svg>
+            </button>
+            <button onClick={redo} className="px-2 py-1 text-[11px] rounded border border-border text-text-secondary hover:bg-surface-hover" title="Redo">
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><path d="M21 10H8a4 4 0 000 8h10" /><path d="M21 10l-4-4M21 10l-4 4" /></svg>
+            </button>
+            <button onClick={deleteSelected} disabled={selectedTags.size === 0} className="px-2 py-1 text-[11px] rounded border border-border text-text-secondary hover:bg-surface-hover disabled:opacity-30" title="Delete selected">
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><path d="M3 6h18M19 6l-1 14H6L5 6M8 6V4h8v2" /></svg>
+            </button>
+            <button onClick={selectAll} className="px-2 py-1 text-[11px] rounded border border-border text-text-secondary hover:bg-surface-hover" title="Select all">
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><rect x="3" y="3" width="18" height="18" rx="2" /><path d="M9 12l2 2 4-4" /></svg>
+            </button>
+            <div className="flex-1" />
+            <span className="text-[11px] text-text-secondary font-mono">
+              {wires.length}W {totalSegments}S
+            </span>
+          </div>
         </div>
+        {simError && (
+          <p className="text-xs text-swr-bad px-3 pb-1">{simError}</p>
+        )}
+        {wires.length > 0 && (
+          <div className="px-3 pb-1 shrink-0">
+            <Slider
+              label="Antenna Height"
+              value={antennaMinZ}
+              min={0}
+              max={100}
+              step={0.5}
+              unit="m"
+              decimals={1}
+              description={`Lowest point: ${antennaMinZ}m, Highest: ${antennaMaxZ}m`}
+              onChange={handleHeightChange}
+            />
+          </div>
+        )}
 
-        <div className="px-3 pb-1 shrink-0">
-          <SegmentedControl
-            segments={MOBILE_SEGMENTS}
-            activeKey={mobileTab}
-            onChange={(key) => setMobileTab(key as MobileEditorTab)}
-
-          />
-        </div>
-
+        {/* Tab content */}
         <div className="px-3 py-2 flex-1 overflow-y-auto">
           {mobileTab === "wires" && <WireTable />}
           {mobileTab === "properties" && <WirePropertiesPanel />}
+          {mobileTab === "settings" && (
+            <div className="space-y-3">
+              {/* Design frequency */}
+              <div className="flex items-center gap-2">
+                <label className="text-[11px] text-text-secondary shrink-0">Design freq:</label>
+                <input
+                  type="number"
+                  step="0.1"
+                  min="0.1"
+                  max="500"
+                  value={designFrequencyMhz}
+                  onChange={(e) => {
+                    const v = parseFloat(e.target.value);
+                    if (!isNaN(v) && v > 0) setDesignFrequency(v);
+                  }}
+                  className="flex-1 bg-background text-text-primary text-xs font-mono px-1.5 py-1 rounded border border-border focus:border-accent/50 outline-none text-right"
+                />
+                <span className="text-[11px] text-text-secondary">MHz</span>
+              </div>
+              {/* Frequency sweep */}
+              <div className="flex items-center gap-1 flex-wrap">
+                <label className="text-[11px] text-text-secondary shrink-0">Sweep:</label>
+                <input
+                  type="number" step="0.1" min="0.1" max="500"
+                  value={frequencyRange.start_mhz}
+                  onChange={(e) => {
+                    const v = parseFloat(e.target.value);
+                    if (!isNaN(v) && v > 0 && v < frequencyRange.stop_mhz) setFrequencyRange({ ...frequencyRange, start_mhz: v });
+                  }}
+                  className="w-16 bg-background text-text-primary text-xs font-mono px-1 py-1 rounded border border-border outline-none text-right"
+                />
+                <span className="text-[11px] text-text-secondary">-</span>
+                <input
+                  type="number" step="0.1" min="0.1" max="500"
+                  value={frequencyRange.stop_mhz}
+                  onChange={(e) => {
+                    const v = parseFloat(e.target.value);
+                    if (!isNaN(v) && v > 0 && v > frequencyRange.start_mhz) setFrequencyRange({ ...frequencyRange, stop_mhz: v });
+                  }}
+                  className="w-16 bg-background text-text-primary text-xs font-mono px-1 py-1 rounded border border-border outline-none text-right"
+                />
+                <span className="text-[11px] text-text-secondary">MHz</span>
+                <input
+                  type="number" step="1" min="1" max="201"
+                  value={frequencyRange.steps}
+                  onChange={(e) => {
+                    const v = parseInt(e.target.value, 10);
+                    if (!isNaN(v) && v >= 1 && v <= 201) setFrequencyRange({ ...frequencyRange, steps: v });
+                  }}
+                  className="w-12 bg-background text-text-primary text-xs font-mono px-1 py-1 rounded border border-border outline-none text-right"
+                />
+                <span className="text-[11px] text-text-secondary">pts</span>
+              </div>
+              {/* Snap size */}
+              <div>
+                <label className="text-[11px] text-text-secondary font-semibold uppercase tracking-wider block mb-1">Snap Size</label>
+                <select value={snapSize} onChange={(e) => setSnapSize(parseFloat(e.target.value))}
+                  className="w-full bg-background text-text-primary text-xs font-mono px-1.5 py-1.5 rounded border border-border outline-none">
+                  <option value="0">Off</option>
+                  <option value="0.01">0.01 m</option>
+                  <option value="0.05">0.05 m</option>
+                  <option value="0.1">0.1 m</option>
+                  <option value="0.25">0.25 m</option>
+                  <option value="0.5">0.5 m</option>
+                  <option value="1">1.0 m</option>
+                </select>
+              </div>
+              {/* Pattern resolution */}
+              <div>
+                <label className="text-[11px] text-text-secondary font-semibold uppercase tracking-wider block mb-1">Pattern Resolution</label>
+                <select value={patternStep} onChange={(e) => setPatternStep(parseInt(e.target.value, 10))}
+                  className="w-full bg-background text-text-primary text-xs font-mono px-1.5 py-1.5 rounded border border-border outline-none">
+                  <option value="1">1 deg (very fine)</option>
+                  <option value="2">2 deg (fine)</option>
+                  <option value="5">5 deg (standard)</option>
+                  <option value="10">10 deg (fast)</option>
+                </select>
+              </div>
+              <GroundEditor ground={ground} onChange={setGround} />
+              <BalunEditor matching={matching} onChange={setMatching} />
+            </div>
+          )}
+          {mobileTab === "tools" && (
+            <div className="space-y-3">
+              {/* Templates */}
+              <div>
+                <h4 className="text-[11px] font-semibold text-text-secondary uppercase tracking-wider mb-1.5">Load Template</h4>
+                <TemplatePicker selectedId={selectedTemplate.id} onSelect={handleTemplateSelect} />
+                <div className="mt-2">
+                  <ParameterPanel parameters={selectedTemplate.parameters} values={templateParams} onParamChange={handleTemplateParamChange} />
+                </div>
+                {wires.length > 0 && (
+                  <p className="text-[11px] text-swr-warning leading-tight mt-1.5">Replaces all current wires.</p>
+                )}
+                <Button onClick={handleLoadTemplate} className="w-full mt-2" size="sm">Load into Editor</Button>
+              </div>
+              <div className="border-t border-border" />
+              {/* Import/Export */}
+              <div>
+                <h4 className="text-[11px] font-semibold text-text-secondary uppercase tracking-wider mb-1.5">Import / Export</h4>
+                <ImportExportPanel />
+              </div>
+              <div className="border-t border-border" />
+              {/* Compare */}
+              <div>
+                <h4 className="text-[11px] font-semibold text-text-secondary uppercase tracking-wider mb-1.5">Compare</h4>
+                <CompareOverlay />
+              </div>
+              <div className="border-t border-border" />
+              {/* Optimizer */}
+              <div>
+                <h4 className="text-[11px] font-semibold text-text-secondary uppercase tracking-wider mb-1.5">Optimizer</h4>
+                <OptimizerPanel />
+              </div>
+            </div>
+          )}
           {mobileTab === "results" && <ResultsPanel />}
-        </div>
-
-        {/* Sticky run button */}
-        <div className="p-2 border-t border-border shrink-0">
-          <Button
-            onClick={handleRunSimulation}
-            loading={isLoading}
-            disabled={isLoading || !canRun}
-            className="w-full"
-            size="sm"
-          >
-            {isLoading ? "Simulating..." : "Run Simulation"}
-          </Button>
         </div>
       </div>
 
-      {/* Status bar */}
-      <div className="flex items-center justify-between px-3 h-6 border-t border-border bg-surface text-[10px] font-mono text-text-secondary shrink-0">
+      {/* Status bar (desktop only) */}
+      <div className="hidden lg:flex items-center justify-between px-3 h-6 border-t border-border bg-surface text-[10px] font-mono text-text-secondary shrink-0">
         <div className="flex items-center gap-3">
           <span>
             Mode: <span className="text-accent">{mode}</span>

--- a/frontend/src/pages/LearnPage.tsx
+++ b/frontend/src/pages/LearnPage.tsx
@@ -403,22 +403,26 @@ export function LearnPage() {
           id="learn-content"
           className="flex-1 overflow-y-auto"
         >
-          {/* Mobile section selector */}
-          <div className="md:hidden sticky top-0 z-10 bg-surface border-b border-border p-2">
-            <select
-              value={activeSection}
-              onChange={(e) => handleSectionClick(e.target.value)}
-              className="w-full bg-background text-text-primary text-sm px-2 py-1.5 rounded border border-border outline-none"
-            >
+          {/* Mobile section selector — horizontal scrollable pills */}
+          <div className="md:hidden sticky top-0 z-10 bg-surface border-b border-border px-2 py-2 overflow-x-auto">
+            <div className="flex gap-1.5 min-w-max">
               {SECTIONS.map((s) => (
-                <option key={s.id} value={s.id}>
+                <button
+                  key={s.id}
+                  onClick={() => handleSectionClick(s.id)}
+                  className={`px-3 py-1.5 text-xs rounded-full whitespace-nowrap transition-colors ${
+                    activeSection === s.id
+                      ? "bg-accent/15 text-accent font-medium border border-accent/40"
+                      : "bg-background text-text-secondary border border-border hover:text-text-primary"
+                  }`}
+                >
                   {s.title}
-                </option>
+                </button>
               ))}
-            </select>
+            </div>
           </div>
 
-          <div className="max-w-3xl mx-auto px-6 py-8">
+          <div className="max-w-3xl mx-auto px-4 py-5 md:px-6 md:py-8">
             <h1 className="text-2xl font-bold text-text-primary mb-6">
               {active.title}
             </h1>

--- a/frontend/src/pages/SimulatorPage.tsx
+++ b/frontend/src/pages/SimulatorPage.tsx
@@ -27,8 +27,6 @@ import { SegmentedControl } from "../components/ui/SegmentedControl";
 import { ColorScale } from "../components/ui/ColorScale";
 import { ResultsPanel } from "../components/results/ResultsTabs";
 import { PatternFrequencySlider } from "../components/results/PatternFrequencySlider";
-import { SWRChart } from "../components/results/SWRChart";
-import { formatSwr, formatGain, formatImpedance, swrColorClass, applyMatching } from "../utils/units";
 import type { AntennaTemplate } from "../templates/types";
 import type { ViewToggles } from "../components/three/types";
 
@@ -58,8 +56,6 @@ export function SimulatorPage() {
   const result = useSimulationStore((s) => s.result);
   const simulate = useSimulationStore((s) => s.simulate);
   const resetSimulation = useSimulationStore((s) => s.reset);
-  const selectedFreqIndex = useSimulationStore((s) => s.selectedFreqIndex);
-  const setSelectedFreqIndex = useSimulationStore((s) => s.setSelectedFreqIndex);
   const selectedFreqResult = useSimulationStore((s) =>
     s.getSelectedFrequencyResult()
   );
@@ -87,11 +83,6 @@ export function SimulatorPage() {
   const handleToggle = useCallback(
     (key: keyof ViewToggles) => toggleView(key),
     [toggleView]
-  );
-
-  const handleFreqClick = useCallback(
-    (index: number) => setSelectedFreqIndex(index),
-    [setSelectedFreqIndex]
   );
 
   // Pattern resolution
@@ -207,7 +198,7 @@ export function SimulatorPage() {
         </aside>
 
         {/* === CENTER: 3D VIEWPORT === */}
-        <main className="flex-1 relative min-w-0">
+        <main className="flex-1 relative min-w-0 min-h-[35vh]">
           <ErrorBoundary label="3D Viewport">
             <SceneRoot
               wires={wireData}
@@ -231,23 +222,10 @@ export function SimulatorPage() {
 
           {/* Pattern frequency slider */}
           {simStatus === "success" && result && result.frequency_data.length > 1 && (
-            <div className="absolute bottom-2 left-1/2 -translate-x-1/2 z-10 w-64 hidden lg:block">
+            <div className="absolute bottom-2 left-1/2 -translate-x-1/2 z-10 w-48 lg:w-64">
               <PatternFrequencySlider />
             </div>
           )}
-
-          {/* Mobile run button (floating) */}
-          <div className="lg:hidden absolute bottom-3 left-1/2 -translate-x-1/2 z-10">
-            <Button
-              onClick={handleRunSimulation}
-              loading={isLoading}
-              disabled={isLoading}
-              size="md"
-              className="shadow-lg shadow-accent/20"
-            >
-              {isLoading ? "Simulating..." : "Run Simulation"}
-            </Button>
-          </div>
         </main>
 
         {/* === RIGHT PANEL (desktop only) === */}
@@ -260,18 +238,27 @@ export function SimulatorPage() {
 
       {/* === MOBILE BOTTOM SHEET === */}
       <div className="lg:hidden border-t border-border bg-surface flex flex-col max-h-[55vh]">
-        {/* Drag handle */}
-        <div className="flex justify-center py-1.5 shrink-0">
-          <div className="w-8 h-1 rounded-full bg-border" />
+        <div className="px-3 pt-2 pb-1 shrink-0 flex items-center gap-2">
+          <div className="flex-1">
+            <SegmentedControl
+              segments={MOBILE_SEGMENTS}
+              activeKey={mobileTab}
+              onChange={(key) => setMobileTab(key as typeof mobileTab)}
+            />
+          </div>
+          <Button
+            onClick={handleRunSimulation}
+            loading={isLoading}
+            disabled={isLoading}
+            size="sm"
+            className="shrink-0"
+          >
+            {isLoading ? "Running..." : "Run"}
+          </Button>
         </div>
-
-        <div className="px-3 pb-1 shrink-0">
-          <SegmentedControl
-            segments={MOBILE_SEGMENTS}
-            activeKey={mobileTab}
-            onChange={(key) => setMobileTab(key as typeof mobileTab)}
-          />
-        </div>
+        {simError && (
+          <p className="text-xs text-swr-bad px-3 pb-1">{simError}</p>
+        )}
         <div className="px-3 py-2 flex-1 overflow-y-auto">
           {mobileTab === "antenna" && (
             <div className="space-y-3">
@@ -286,73 +273,38 @@ export function SimulatorPage() {
               />
               <GroundEditor ground={ground} onChange={setGround} />
               <BalunEditor matching={matching} onChange={setMatching} />
-            </div>
-          )}
-          {mobileTab === "results" && (
-            <div className="space-y-3">
-              {simStatus === "idle" && (
-                <p className="text-xs text-text-secondary text-center py-4">
-                  Run a simulation to see results.
-                </p>
-              )}
-              {simStatus === "success" && selectedFreqResult && (() => {
-                const m = applyMatching(
-                  selectedFreqResult.impedance.real,
-                  selectedFreqResult.impedance.imag,
-                  matching
-                );
-                return (
-                  <>
-                    {/* Quick summary cards */}
-                    <div className="grid grid-cols-3 gap-2">
-                      <div className="bg-background rounded-md p-2">
-                        <div className="text-[10px] text-text-secondary">SWR</div>
-                        <div
-                          className={`text-base font-mono font-bold ${swrColorClass(m.swr)}`}
-                        >
-                          {formatSwr(m.swr)}
-                        </div>
-                      </div>
-                      <div className="bg-background rounded-md p-2">
-                        <div className="text-[10px] text-text-secondary">Gain</div>
-                        <div className="text-base font-mono font-bold text-text-primary">
-                          {formatGain(selectedFreqResult.gain_max_dbi)}
-                        </div>
-                      </div>
-                      <div className="bg-background rounded-md p-2">
-                        <div className="text-[10px] text-text-secondary">Z</div>
-                        <div className="text-[10px] font-mono text-text-primary">
-                          {formatImpedance(m.real, m.imag)}
-                        </div>
-                      </div>
-                    </div>
 
-                    {/* SWR chart (compact) */}
-                    {result && (
-                      <div>
-                        <h4 className="text-[10px] text-text-secondary mb-1">SWR vs Frequency</h4>
-                        <SWRChart
-                          data={result.frequency_data}
-                          onFrequencyClick={handleFreqClick}
-                          selectedIndex={selectedFreqIndex}
-                          matching={matching}
-                        />
-                      </div>
-                    )}
-                  </>
-                );
-              })()}
-              {simStatus === "loading" && (
-                <div className="flex items-center justify-center py-6">
-                  <div className="w-6 h-6 border-2 border-accent border-t-transparent rounded-full animate-spin" />
-                </div>
-              )}
+              {/* Pattern resolution */}
+              <div className="space-y-1">
+                <h3 className="text-xs font-medium text-text-secondary uppercase tracking-wider">
+                  Pattern Resolution
+                </h3>
+                <select
+                  value={patternStep}
+                  onChange={(e) => setPatternStep(parseInt(e.target.value, 10))}
+                  className="w-full bg-background text-text-primary text-xs font-mono px-1.5 py-1.5 rounded border border-border outline-none"
+                >
+                  <option value="1">1° (very fine — slow)</option>
+                  <option value="2">2° (fine)</option>
+                  <option value="5">5° (standard)</option>
+                  <option value="10">10° (fast)</option>
+                </select>
+                {patternStep <= 2 && (
+                  <p className="text-[11px] text-swr-warning leading-tight">
+                    Fine resolution increases computation time significantly.
+                  </p>
+                )}
+              </div>
             </div>
           )}
+          {mobileTab === "results" && <ResultsPanel />}
         </div>
       </div>
 
-      <StatusBar />
+      {/* StatusBar (desktop only — mobile has essential info in overlays) */}
+      <div className="hidden lg:block">
+        <StatusBar />
+      </div>
 
       <KeyboardShortcutsPanel
         isOpen={shortcutsOpen}


### PR DESCRIPTION
## Summary
Comprehensive mobile UI overhaul addressing broken navigation, inaccessible editor features, tiny touch targets, overflowing tables, and missing functionality on small screens. Also includes desktop improvements: camera follow on height change, screenshot fix, and editor empty-state hint.
**Navigation:**
- Hamburger menu with all 5 nav links, auto-closes on route change and outside click
**Simulator mobile:**
- Full `ResultsPanel` with all 5 chart tabs (SWR, Z, Smith, Pattern, Gain) — previously only showed SWR
- Pattern resolution select added to antenna tab
- Run button in bottom sheet header
**Editor mobile (5 tabs):**
- Expanded from 3 to 5 tabs: Wires | Props | Settings | Tools | Results
- Settings: design frequency, sweep range, snap, pattern resolution, ground, balun
- Tools: template loader, import/export, compare, optimizer
- Compact operations bar with undo/redo/delete/select-all icons
- Auto-switches to Results tab on simulation success
- Height slider always visible in bottom sheet, above tab content
**Wire Table:**
- Mobile card layout with tap-to-edit replacing the overflowing desktop table
**Editor UX:**
- Height slider moved from Settings to bottom section (desktop: above Run, mobile: persistent in sheet) using the standard `<Slider>` component
- Empty-state hint when no wires exist: "Switch to Add mode or go to Tools"
- S/A/M mode buttons moved to top-left to avoid gizmo overlap
**Camera follow:**
- Camera tracks the antenna instantly when height changes (editor + simulator)
- Uses raw wire centroid for 1:1 tracking, unaffected by ground plane padding
- User orbit/pan fully respected — follow applies delta from current position
**Screenshot fix:**
- Added `preserveDrawingBuffer: true` to both Canvas configs so `toDataURL()` works
**Learn page:**
- Replaced native `<select>` (broke in Chrome responsive mode) with horizontal scrollable pill buttons
- Tighter content padding on mobile
**Touch & readability:**
- Slider thumb 14px → 20px, track 6px → 8px
- Button/SegmentedControl padding increases
- `text-[10px]` → `text-[11px]` across 6 editor panel components
- ViewToggleToolbar popover buttons enlarged
**Files changed:** 17 | **+679 / -391**