### PR TITLE
feat: add MCP server for LLM-driven antenna simulation

### DIFF
--- a/mcp/.gitignore
+++ b/mcp/.gitignore
@@ -1,0 +1,23 @@
+# Build artifacts
+*.egg-info/
+dist/
+build/
+
+# Virtual environments
+.venv/
+venv/
+
+# Python cache
+__pycache__/
+*.pyc
+*.pyo
+
+# IDE
+.idea/
+.vscode/
+*.swp
+*.swo
+
+# OS
+.DS_Store
+Thumbs.db

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -1,0 +1,628 @@
+# AntennaSim MCP Server
+
+This MCP server exposes **AntennaSim's NEC2-based antenna simulation capabilities** as tools that LLM clients can call over **stdio**.
+
+It is designed to let agents and chat assistants:
+
+- list and inspect antenna templates
+- pick ham bands and sweep ranges
+- generate NEC2 geometry from **19 predefined antenna templates**
+- design custom wire antennas from a compact endpoint-based string format
+- inspect/export the raw NEC2 card deck for a template configuration
+- run `nec2c`
+- compare antennas side by side
+- analyze one design for a specific amateur band
+- simulate arbitrary custom wire geometries
+
+The server is **standalone** and **does not require Redis**.
+
+---
+
+## What it does
+
+The server provides these tool families:
+
+1. **Discovery and documentation**
+   - `list_antenna_templates`
+   - `get_template_info`
+   - `list_ham_bands`
+
+2. **Template-driven simulation**
+   - `create_and_simulate_antenna`
+   - `compare_antennas`
+   - `analyze_antenna_for_band`
+
+3. **Guided custom wire design**
+   - `design_wire_antenna`
+
+4. **Raw geometry and export**
+   - `simulate_custom_antenna`
+   - `get_nec2_card_deck`
+
+Internally, the MCP server:
+
+- ports the frontend antenna template math to Python
+- adds `AntennaSim/backend` to `sys.path`
+- imports the backend NEC request models and parser directly
+- builds NEC2 geometry and feed definitions from template or custom inputs
+- runs `nec2c` for simulation tools
+- can emit the raw NEC2 card deck for exporting, learning, and debugging
+- parses impedance, SWR, gain, pattern, and related metrics
+- returns LLM-friendly text summaries and tables
+
+---
+
+## Built-in templates
+
+The server currently includes **19** built-in templates:
+
+- **Wire:** `dipole`, `inverted-v`, `efhw`, `random-wire`
+- **Vertical:** `vertical`, `inverted-l`, `j-pole`, `slim-jim`
+- **Multiband:** `off-center-fed`, `fan-dipole`, `g5rv`
+- **Loop:** `delta-loop`, `horizontal-delta-loop`, `magnetic-loop`
+- **Directional:** `quad`, `yagi`, `moxon`, `hex-beam`, `log-periodic`
+
+Use `list_antenna_templates` for descriptions, bands, and difficulty, or `get_template_info(template_id)` for the full parameter list for one design.
+
+---
+
+## Prerequisites
+
+You need:
+
+- **Python 3.12+**
+- **`nec2c` installed and available on your PATH**
+- this repository checked out so the MCP code can find the backend
+
+Expected repository layout:
+
+```text
+AntennaSim/
+  backend/
+  frontend/
+  mcp/
+```
+
+If your layout is different, set:
+
+```bash
+ANTENNASIM_BACKEND_DIR=/full/path/to/AntennaSim/backend
+```
+
+### `nec2c` requirement
+
+The simulation tools call the external `nec2c` executable.
+
+Make sure this works before using the MCP server:
+
+```bash
+nec2c -h
+```
+
+If your platform package manager does not provide `nec2c`, build/install it from source and ensure the executable is on `PATH`.
+
+---
+
+## Installation
+
+From the `AntennaSim/mcp` directory:
+
+```bash
+cd AntennaSim/mcp
+python -m venv .venv
+source .venv/bin/activate
+pip install -e .
+```
+
+On Windows PowerShell:
+
+```powershell
+cd AntennaSim\mcp
+python -m venv .venv
+.venv\Scripts\Activate.ps1
+pip install -e .
+```
+
+After install, you can launch the server either as:
+
+```bash
+python server.py
+```
+
+or:
+
+```bash
+antsim-mcp
+```
+
+---
+
+## Environment variables
+
+The server can use these useful environment variables:
+
+- `ANTENNASIM_BACKEND_DIR`  
+  Full path to `AntennaSim/backend` if it is not in the default sibling location.
+
+- `SIM_TIMEOUT_SECONDS`  
+  Passed through the backend settings loader. Controls the `nec2c` timeout.
+
+- `NEC_WORKDIR`  
+  Passed through the backend settings loader. Controls where temporary NEC files are written.
+
+Example:
+
+```bash
+export ANTENNASIM_BACKEND_DIR=/full/path/to/AntennaSim/backend
+export SIM_TIMEOUT_SECONDS=180
+export NEC_WORKDIR=/tmp/nec_workdir
+```
+
+---
+
+## MCP client configuration
+
+### Claude Desktop
+
+Example config using the virtualenv Python interpreter and the source file directly:
+
+```json
+{
+  "mcpServers": {
+    "antsim": {
+      "command": "/full/path/to/AntennaSim/mcp/.venv/bin/python",
+      "args": ["/full/path/to/AntennaSim/mcp/server.py"],
+      "env": {
+        "ANTENNASIM_BACKEND_DIR": "/full/path/to/AntennaSim/backend"
+      }
+    }
+  }
+}
+```
+
+If you prefer the installed console script, use:
+
+```json
+{
+  "mcpServers": {
+    "antsim": {
+      "command": "/full/path/to/AntennaSim/mcp/.venv/bin/antsim-mcp",
+      "args": [],
+      "env": {
+        "ANTENNASIM_BACKEND_DIR": "/full/path/to/AntennaSim/backend"
+      }
+    }
+  }
+}
+```
+
+### Cursor
+
+Example `.cursor/mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "antsim": {
+      "command": "/full/path/to/AntennaSim/mcp/.venv/bin/python",
+      "args": ["/full/path/to/AntennaSim/mcp/server.py"],
+      "env": {
+        "ANTENNASIM_BACKEND_DIR": "/full/path/to/AntennaSim/backend"
+      }
+    }
+  }
+}
+```
+
+### Generic stdio MCP clients
+
+Any stdio-based MCP client can launch:
+
+```bash
+/full/path/to/AntennaSim/mcp/.venv/bin/python /full/path/to/AntennaSim/mcp/server.py
+```
+
+---
+
+## Available tools
+
+## 1) `list_antenna_templates`
+
+Lists all **19** built-in templates with:
+
+- template ID
+- name
+- category
+- difficulty
+- typical bands
+- one-line description
+
+Use this first when you want to discover what the server can simulate.
+
+---
+
+## 2) `get_template_info`
+
+Returns detailed info for a specific template:
+
+- full description
+- parameter list
+- parameter ranges
+- defaults
+- default sweep range
+- tips
+- related templates
+
+Example:
+
+- `template_id = "dipole"`
+- `template_id = "moxon"`
+- `template_id = "inverted-l"`
+- `template_id = "random-wire"`
+
+---
+
+## 3) `list_ham_bands`
+
+Lists amateur bands for an ITU region (`r1`, `r2`, `r3`) with:
+
+- label
+- name
+- start/stop frequencies
+- center frequency
+- suggested sweep point count
+
+Example:
+
+- `region = "r1"`
+- `region = "r2"`
+
+---
+
+## 4) `create_and_simulate_antenna`
+
+Creates a template antenna from parameters and runs a NEC2 sweep.
+
+Arguments:
+
+- `template_id` — required
+- `params` — JSON object string, optional
+- `ground_type` — preset string, optional
+- `freq_start_mhz` — optional
+- `freq_stop_mhz` — optional
+- `freq_steps` — optional
+
+If frequency arguments are omitted, the template's default sweep is used.
+
+### Example `params` JSON
+
+```json
+{"frequency": 14.1, "height": 10, "wire_diameter": 2.0}
+```
+
+### Ground presets
+
+Supported preset names:
+
+- `free_space`
+- `perfect`
+- `salt_water`
+- `fresh_water`
+- `pastoral`
+- `average`
+- `rocky`
+- `city`
+- `dry_sandy`
+- `custom`
+
+You can also pass **custom ground values** in this compact string form:
+
+```text
+custom:13,0.005
+```
+
+which means:
+
+- relative dielectric constant `εr = 13`
+- conductivity `σ = 0.005 S/m`
+
+---
+
+## 5) `compare_antennas`
+
+Simulates two antennas on the same sweep and returns side-by-side comparisons of:
+
+- best SWR
+- impedance
+- gain
+- front-to-back
+- beamwidth summary
+- efficiency
+- per-frequency comparison table
+
+Arguments:
+
+- `antenna1_template`
+- `antenna2_template`
+- `antenna1_params`
+- `antenna2_params`
+- `freq_start_mhz`
+- `freq_stop_mhz`
+- `freq_steps`
+- `ground_type`
+
+If the sweep range is omitted, the server builds one from the two templates' defaults.
+
+---
+
+## 6) `analyze_antenna_for_band`
+
+Runs a simulation specifically across one ham band and returns band-focused metrics such as:
+
+- minimum SWR in the band
+- best frequency
+- usable bandwidth where SWR <= 2.0
+- average gain
+- peak gain
+- center-of-band impedance
+- quality rating
+
+Arguments:
+
+- `template_id`
+- `band` (example: `20m`, `40m`, `2m`)
+- `params`
+- `ground_type`
+
+Band definitions currently use the Region 1 table for band-targeted analysis.
+
+---
+
+## 7) `design_wire_antenna`
+
+Simulates a custom wire antenna from a compact semicolon-separated wire list instead of raw JSON.
+
+This tool is meant to be easier for an LLM to construct than `simulate_custom_antenna` when the antenna can be described as a set of wire endpoints plus a feed location.
+
+Arguments:
+
+- `wires`
+- `feed_wire_tag`
+- `feed_segment`
+- `freq_start_mhz`
+- `freq_stop_mhz`
+- `freq_steps`
+- `ground_type`
+- `antenna_name`
+
+### `wires` format
+
+The `wires` value is a semicolon-separated list where each wire is:
+
+```text
+tag,segments,x1,y1,z1,x2,y2,z2,radius
+```
+
+All coordinates and the radius are in **meters**.
+
+Example:
+
+```text
+1,21,0,0,10,-5,0,10,0.001;2,21,0,0,10,5,0,10,0.001
+```
+
+That example describes two wires starting from the same feedpoint at 10 m height, one extending 5 m left and one 5 m right, each with radius `0.001 m`.
+
+### Feed definition
+
+- `feed_wire_tag` must match a unique wire tag in the design
+- `feed_segment` selects the segment on that wire where the source is applied
+
+---
+
+## 8) `simulate_custom_antenna`
+
+Advanced raw geometry simulation.
+
+Arguments:
+
+- `wires_json`
+- `excitation_json`
+- `freq_start_mhz`
+- `freq_stop_mhz`
+- `freq_steps`
+- `ground_type`
+
+### `wires_json` format
+
+A JSON array of wire objects matching the backend wire schema:
+
+```json
+[
+  {
+    "tag": 1,
+    "segments": 11,
+    "x1": -5.0,
+    "y1": 0.0,
+    "z1": 10.0,
+    "x2": 0.0,
+    "y2": 0.0,
+    "z2": 10.0,
+    "radius": 0.001
+  },
+  {
+    "tag": 2,
+    "segments": 11,
+    "x1": 0.0,
+    "y1": 0.0,
+    "z1": 10.0,
+    "x2": 5.0,
+    "y2": 0.0,
+    "z2": 10.0,
+    "radius": 0.001
+  }
+]
+```
+
+### `excitation_json` format
+
+Single excitation object:
+
+```json
+{
+  "wire_tag": 1,
+  "segment": 11,
+  "voltage_real": 1.0,
+  "voltage_imag": 0.0
+}
+```
+
+Or an array of excitations:
+
+```json
+[
+  {
+    "wire_tag": 1,
+    "segment": 11,
+    "voltage_real": 1.0,
+    "voltage_imag": 0.0
+  }
+]
+```
+
+---
+
+## 9) `get_nec2_card_deck`
+
+Returns the raw NEC2 card deck for a **template configuration** without running `nec2c`.
+
+This is useful for:
+
+- exporting a template design into a standalone NEC2 deck
+- learning what cards a given antenna template produces
+- debugging geometry, feed, ground, and sweep setup
+
+Arguments:
+
+- `template_id`
+- `params`
+- `ground_type`
+- `freq_start_mhz`
+- `freq_stop_mhz`
+- `freq_steps`
+
+If frequency arguments are omitted, the template's default sweep is used.
+
+The returned text is plain NEC2 input, including comment cards and cards such as:
+
+- `CM`
+- `GW`
+- `GE`
+- `GN`
+- `EX`
+- `FR`
+- `RP`
+- `EN`
+
+Unlike the simulation tools, this tool does **not** invoke `nec2c`.
+
+---
+
+## Example prompts
+
+Here are good prompts to try in an MCP-capable client.
+
+### Discovery
+
+- “List the available antenna templates and recommend good options for a 20 meter portable antenna.”
+- “Show me the details for the `inverted-l` template.”
+- “Show me the details for the `random-wire` template.”
+- “List Region 2 ham bands with frequencies.”
+
+### Simple template simulations
+
+- “Simulate a 20 meter dipole at 10 meters over average ground.”
+- “Create a 40 meter inverted-V with a 12 meter apex and a 120 degree included angle.”
+- “Simulate a 40 meter inverted-L with a 6 meter vertical section, 4 radials, and average ground.”
+- “Model a 25 meter random wire with the feed at 8 m, far end at 3 m, and a 5 m counterpoise.”
+- “Simulate a 2 meter J-pole at 145 MHz.”
+
+### Comparisons
+
+- “Compare a 20 meter dipole at 10 m with a 20 meter vertical with 4 radials over average ground.”
+- “Compare a 3-element Yagi and a 2-element quad for 14.15 MHz at 12 m height.”
+- “Which is better on 10 meters: a Moxon or a Hex Beam?”
+
+### Band-specific analysis
+
+- “Analyze a 40 meter EFHW for the 40m band.”
+- “Check how well a G5RV covers the 20 meter band.”
+- “Analyze an off-center-fed dipole for 80 meters.”
+
+### Advanced custom geometry and export
+
+- “Design a custom wire antenna using `1,21,0,0,10,-5,0,10,0.001;2,21,0,0,10,5,0,10,0.001`, feed wire 1 segment 1, and sweep 14.0 to 14.35 MHz.”
+- “Simulate this custom two-wire dipole geometry over salt water.”
+- “Take this raw NEC wire geometry and tell me the SWR sweep from 14.0 to 14.35 MHz.”
+- “Show me the raw NEC2 card deck for an inverted-L on 7.1 MHz with a 6 meter vertical section.”
+- “Export the NEC2 card deck for a random-wire template so I can study the `GW`, `GN`, `EX`, and `FR` cards.”
+
+---
+
+## Notes and implementation details
+
+- The MCP server imports the **backend's NEC request models, card-deck builder inputs, runner, and parser directly**.
+- It does **not** require Redis.
+- The new **Inverted-L** template models a quarter-wave total wire length with a vertical section plus a horizontal top wire and base radials.
+- The new **Random Wire** template models a non-resonant end-fed wire with a short counterpoise at the feedpoint.
+- The `design_wire_antenna` tool accepts a compact semicolon-separated wire syntax that is easier for LLMs to produce than raw JSON arrays.
+- The `get_nec2_card_deck` tool returns exportable NEC2 text without running `nec2c`.
+- The magnetic loop template uses a **36-segment straight-wire approximation**, matching the frontend preview geometry logic.
+- Template parameter math, segmentation, Yagi dimensions, Moxon formulas, LPDA math, and band-selection logic are ported from the frontend TypeScript source where applicable.
+- Results are formatted as readable text so LLMs can summarize them cleanly for users.
+
+---
+
+## Troubleshooting
+
+### “nec2c executable not found”
+
+Install `nec2c` and ensure it is on your shell PATH:
+
+```bash
+nec2c -h
+```
+
+### “Could not locate AntennaSim/backend”
+
+Set:
+
+```bash
+export ANTENNASIM_BACKEND_DIR=/full/path/to/AntennaSim/backend
+```
+
+### MCP client starts, but simulation tools fail
+
+Check:
+
+1. `nec2c` is installed
+2. the backend directory is accessible
+3. your Python environment includes:
+   - `mcp`
+   - `pydantic`
+   - `pydantic-settings`
+
+---
+
+## Quick start summary
+
+```bash
+cd AntennaSim/mcp
+python -m venv .venv
+source .venv/bin/activate
+pip install -e .
+export ANTENNASIM_BACKEND_DIR=/full/path/to/AntennaSim/backend
+python server.py
+```
+
+Then connect your MCP client to that stdio process and start calling the tools.

--- a/mcp/__init__.py
+++ b/mcp/__init__.py
@@ -1,0 +1,3 @@
+"""AntennaSim MCP server source files."""
+
+__version__ = "1.0.0"

--- a/mcp/ham_bands.py
+++ b/mcp/ham_bands.py
@@ -1,0 +1,212 @@
+"""Amateur radio band definitions and analysis helpers.
+
+Ported from frontend/src/utils/ham-bands.ts.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import Any, Literal, Mapping, Sequence
+
+Region = Literal["all", "r1", "r2", "r3"]
+BandQuality = Literal["excellent", "good", "marginal", "poor", "not_simulated"]
+
+
+@dataclass(frozen=True, slots=True)
+class HamBand:
+    """A standard amateur radio band allocation."""
+
+    label: str
+    name: str
+    start_mhz: float
+    stop_mhz: float
+    center_mhz: float
+    region: Region
+
+
+@dataclass(frozen=True, slots=True)
+class BandPerformance:
+    """Performance summary for one band."""
+
+    band: HamBand
+    simulated: bool
+    point_count: int
+    min_swr: float | None
+    min_swr_freq_mhz: float | None
+    usable_bandwidth_khz: int | None
+    avg_gain_dbi: float | None
+    peak_gain_dbi: float | None
+    quality: BandQuality
+
+
+HAM_BANDS: list[HamBand] = [
+    HamBand("160m", "160 meters", 1.800, 2.000, 1.900, "all"),
+    HamBand("80m", "80 meters", 3.500, 3.800, 3.650, "r1"),
+    HamBand("80m", "80 meters", 3.500, 4.000, 3.750, "r2"),
+    HamBand("60m", "60 meters", 5.3515, 5.3665, 5.359, "all"),
+    HamBand("40m", "40 meters", 7.000, 7.200, 7.100, "r1"),
+    HamBand("40m", "40 meters", 7.000, 7.300, 7.150, "r2"),
+    HamBand("30m", "30 meters", 10.100, 10.150, 10.125, "all"),
+    HamBand("20m", "20 meters", 14.000, 14.350, 14.175, "all"),
+    HamBand("17m", "17 meters", 18.068, 18.168, 18.118, "all"),
+    HamBand("15m", "15 meters", 21.000, 21.450, 21.225, "all"),
+    HamBand("12m", "12 meters", 24.890, 24.990, 24.940, "all"),
+    HamBand("10m", "10 meters", 28.000, 29.700, 28.850, "all"),
+    HamBand("6m", "6 meters", 50.000, 54.000, 52.000, "all"),
+    HamBand("2m", "2 meters", 144.000, 148.000, 146.000, "all"),
+    HamBand("70cm", "70 cm", 420.000, 450.000, 435.000, "all"),
+]
+
+
+def _js_round(value: float, digits: int = 0) -> float:
+    """Round like JavaScript's Math.round, including midpoint behavior."""
+    factor = 10**digits
+    scaled = value * factor
+    if scaled >= 0:
+        return math.floor(scaled + 0.5) / factor
+    return math.ceil(scaled - 0.5) / factor
+
+
+def compute_steps(start_mhz: float, stop_mhz: float) -> int:
+    """Compute sweep points exactly like the TypeScript helper."""
+    bw = abs(stop_mhz - start_mhz)
+    return int(max(21, min(101, _js_round(bw * 25) + 1)))
+
+
+def get_bands_for_region(region: Literal["r1", "r2", "r3"] = "r1") -> list[HamBand]:
+    """Return bands matching the requested ITU region or 'all'."""
+    if region not in {"r1", "r2", "r3"}:
+        raise ValueError("region must be one of: r1, r2, r3")
+    return [band for band in HAM_BANDS if band.region == "all" or band.region == region]
+
+
+def get_band_by_label(label: str, region: Literal["r1", "r2", "r3"] = "r1") -> HamBand:
+    """Look up a band by short label or full name.
+
+    Region-specific matches are preferred for the requested region.
+    """
+    normalized = label.strip().casefold()
+    for band in get_bands_for_region(region):
+        if band.label.casefold() == normalized or band.name.casefold() == normalized:
+            return band
+    for band in HAM_BANDS:
+        if band.label.casefold() == normalized or band.name.casefold() == normalized:
+            return band
+    raise ValueError(f"Unknown ham band: {label!r}")
+
+
+def band_to_frequency_range(band: HamBand) -> dict[str, float | int]:
+    """Convert a band definition to a default sweep range."""
+    return {
+        "start_mhz": band.start_mhz,
+        "stop_mhz": band.stop_mhz,
+        "steps": compute_steps(band.start_mhz, band.stop_mhz),
+    }
+
+
+def _result_value(result: Any, key: str) -> Any:
+    """Read a field from either a mapping or an object with attributes."""
+    if isinstance(result, Mapping):
+        return result[key]
+    return getattr(result, key)
+
+
+def analyze_band_performance(
+    results: Sequence[Any],
+    region: Literal["r1", "r2", "r3"] = "r1",
+    swr_threshold: float = 2.0,
+) -> list[BandPerformance]:
+    """Analyze simulation results across all defined bands for one region.
+
+    This matches the frontend logic:
+    - find all frequency points that fall inside each band
+    - determine min SWR and where it occurs
+    - estimate usable bandwidth where SWR <= threshold
+    - compute average and peak gain across the band
+    - assign a quality rating based on minimum SWR
+    """
+    performances: list[BandPerformance] = []
+
+    for band in get_bands_for_region(region):
+        in_band = [
+            result
+            for result in results
+            if band.start_mhz <= float(_result_value(result, "frequency_mhz")) <= band.stop_mhz
+        ]
+
+        if not in_band:
+            performances.append(
+                BandPerformance(
+                    band=band,
+                    simulated=False,
+                    point_count=0,
+                    min_swr=None,
+                    min_swr_freq_mhz=None,
+                    usable_bandwidth_khz=None,
+                    avg_gain_dbi=None,
+                    peak_gain_dbi=None,
+                    quality="not_simulated",
+                )
+            )
+            continue
+
+        min_swr = math.inf
+        min_swr_freq = 0.0
+        for result in in_band:
+            swr = float(_result_value(result, "swr_50"))
+            if swr < min_swr:
+                min_swr = swr
+                min_swr_freq = float(_result_value(result, "frequency_mhz"))
+
+        usable = [result for result in in_band if float(_result_value(result, "swr_50")) <= swr_threshold]
+        usable_bandwidth_khz: int | None = None
+        if usable:
+            min_freq = min(float(_result_value(result, "frequency_mhz")) for result in usable)
+            max_freq = max(float(_result_value(result, "frequency_mhz")) for result in usable)
+            usable_bandwidth_khz = int(_js_round((max_freq - min_freq) * 1000))
+
+        gains = [
+            float(_result_value(result, "gain_max_dbi"))
+            for result in in_band
+            if float(_result_value(result, "gain_max_dbi")) > -999.0
+        ]
+        avg_gain = sum(gains) / len(gains) if gains else None
+        peak_gain = max(gains) if gains else None
+
+        if min_swr <= 1.5:
+            quality: BandQuality = "excellent"
+        elif min_swr <= 2.0:
+            quality = "good"
+        elif min_swr <= 3.0:
+            quality = "marginal"
+        else:
+            quality = "poor"
+
+        performances.append(
+            BandPerformance(
+                band=band,
+                simulated=True,
+                point_count=len(in_band),
+                min_swr=_js_round(min_swr, 2),
+                min_swr_freq_mhz=_js_round(min_swr_freq, 3),
+                usable_bandwidth_khz=usable_bandwidth_khz,
+                avg_gain_dbi=_js_round(avg_gain, 2) if avg_gain is not None else None,
+                peak_gain_dbi=_js_round(peak_gain, 2) if peak_gain is not None else None,
+                quality=quality,
+            )
+        )
+
+    return performances
+
+
+__all__ = [
+    "BandPerformance",
+    "HAM_BANDS",
+    "HamBand",
+    "analyze_band_performance",
+    "band_to_frequency_range",
+    "compute_steps",
+    "get_band_by_label",
+    "get_bands_for_region",
+]

--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -1,0 +1,22 @@
+[project]
+name = "antsim-mcp-server"
+version = "1.0.0"
+description = "MCP server exposing AntennaSim NEC2 antenna simulation tools"
+readme = "README.md"
+requires-python = ">=3.12"
+dependencies = [
+    "mcp>=1.0.0",
+    "pydantic>=2.10.0",
+    "pydantic-settings>=2.6.0",
+]
+
+[project.scripts]
+antsim-mcp = "server:main"
+
+[build-system]
+requires = ["setuptools>=69.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools]
+packages = []
+py-modules = ["ham_bands", "templates", "simulator", "server"]

--- a/mcp/server.py
+++ b/mcp/server.py
@@ -1,0 +1,1293 @@
+"""FastMCP server exposing AntennaSim antenna simulation tools."""
+
+from __future__ import annotations
+
+import json
+import math
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any
+
+from mcp.server.fastmcp import FastMCP
+
+try:
+    from .ham_bands import analyze_band_performance, band_to_frequency_range, get_band_by_label, get_bands_for_region
+    from .simulator import (
+        BackendImportError,
+        GROUND_TYPE_VALUES,
+        NecNotFoundError,
+        SimulationArtifacts,
+        SimulationError,
+        parse_ground_spec,
+        simulate,
+    )
+    from .templates import (
+        AntennaTemplate,
+        Excitation,
+        FrequencyRange,
+        TEMPLATES,
+        TemplateNotFoundError,
+        TemplateParameterError,
+        WireGeometry,
+        get_template,
+        resolve_params,
+    )
+except ImportError:
+    from ham_bands import analyze_band_performance, band_to_frequency_range, get_band_by_label, get_bands_for_region
+    from simulator import (
+        BackendImportError,
+        GROUND_TYPE_VALUES,
+        NecNotFoundError,
+        SimulationArtifacts,
+        SimulationError,
+        parse_ground_spec,
+        simulate,
+    )
+    from templates import (
+        AntennaTemplate,
+        Excitation,
+        FrequencyRange,
+        TEMPLATES,
+        TemplateNotFoundError,
+        TemplateParameterError,
+        WireGeometry,
+        get_template,
+        resolve_params,
+    )
+
+
+mcp = FastMCP("AntennaSim MCP")
+
+
+@dataclass(slots=True)
+class TemplateRun:
+    """Resolved template run information."""
+
+    template: AntennaTemplate
+    params: dict[str, float]
+    wires: list[WireGeometry]
+    excitation: Excitation
+    frequency_range: FrequencyRange
+    ground_spec: str
+    artifacts: SimulationArtifacts
+
+
+def _format_exception(exc: Exception) -> str:
+    if isinstance(exc, TemplateNotFoundError):
+        return f"Error: unknown template.\n{exc}"
+    if isinstance(exc, TemplateParameterError):
+        return f"Error: invalid template parameters.\n{exc}"
+    if isinstance(exc, NecNotFoundError):
+        return (
+            "Error: nec2c is not installed or is not on PATH.\n"
+            "Install nec2c first, then restart the MCP client.\n"
+            f"Details: {exc}"
+        )
+    if isinstance(exc, BackendImportError):
+        return (
+            "Error: could not locate or import the AntennaSim backend.\n"
+            "Ensure this MCP server sits beside AntennaSim/backend, or set "
+            "ANTENNASIM_BACKEND_DIR to the backend directory.\n"
+            f"Details: {exc}"
+        )
+    if isinstance(exc, SimulationError):
+        return f"Error: NEC2 simulation failed.\n{exc}"
+    return f"Error: {type(exc).__name__}: {exc}"
+
+
+def _is_non_string_sequence(value: Any) -> bool:
+    return isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray, Mapping))
+
+
+def _value(item: Any, key: str) -> Any:
+    if isinstance(item, Mapping):
+        return item[key]
+    return getattr(item, key)
+
+
+def _parse_json_object(text: str, label: str) -> dict[str, Any]:
+    stripped = text.strip()
+    if not stripped:
+        return {}
+    data = json.loads(stripped)
+    if not isinstance(data, dict):
+        raise ValueError(f"{label} must be a JSON object.")
+    return data
+
+
+def _parse_wires_json(text: str) -> list[dict[str, Any]]:
+    stripped = text.strip()
+    if not stripped:
+        raise ValueError("wires_json must be a JSON array of wire objects.")
+    data = json.loads(stripped)
+    if isinstance(data, dict) and "wires" in data:
+        data = data["wires"]
+    if not isinstance(data, list):
+        raise ValueError("wires_json must be a JSON array, or an object containing a 'wires' array.")
+    return [dict(item) if isinstance(item, Mapping) else item for item in data]
+
+
+def _parse_excitations_json(text: str) -> dict[str, Any] | list[dict[str, Any]]:
+    stripped = text.strip()
+    if not stripped:
+        raise ValueError("excitation_json must be a JSON object or JSON array.")
+    data = json.loads(stripped)
+    if isinstance(data, dict):
+        if "excitations" in data:
+            nested = data["excitations"]
+            if not isinstance(nested, list):
+                raise ValueError("'excitations' must be a JSON array.")
+            return [dict(item) if isinstance(item, Mapping) else item for item in nested]
+        if "excitation" in data:
+            nested = data["excitation"]
+            if isinstance(nested, list):
+                return [dict(item) if isinstance(item, Mapping) else item for item in nested]
+            if isinstance(nested, Mapping):
+                return dict(nested)
+            raise ValueError("'excitation' must be a JSON object or array.")
+        return dict(data)
+    if isinstance(data, list):
+        return [dict(item) if isinstance(item, Mapping) else item for item in data]
+    raise ValueError("excitation_json must be a JSON object or JSON array.")
+
+
+def _format_number(value: float, decimals: int | None = None) -> str:
+    if decimals is not None:
+        return f"{value:.{decimals}f}"
+    if math.isclose(value, round(value), abs_tol=1e-9):
+        return str(int(round(value)))
+    return f"{value:.3f}".rstrip("0").rstrip(".")
+
+
+def _format_impedance(result: Any) -> str:
+    real = float(result.impedance.real)
+    imag = float(result.impedance.imag)
+    sign = "+" if imag >= 0 else "-"
+    return f"{real:.2f} {sign} j{abs(imag):.2f} Ω"
+
+
+def _format_frequency_range(frequency_range: FrequencyRange) -> str:
+    return (
+        f"{frequency_range.start_mhz:.3f} to {frequency_range.stop_mhz:.3f} MHz "
+        f"({frequency_range.steps} points)"
+    )
+
+
+def _format_table(headers: Sequence[str], rows: Sequence[Sequence[str]]) -> str:
+    widths = [len(header) for header in headers]
+    for row in rows:
+        for index, cell in enumerate(row):
+            widths[index] = max(widths[index], len(str(cell)))
+
+    def render(row: Sequence[str]) -> str:
+        return " | ".join(str(cell).ljust(widths[index]) for index, cell in enumerate(row))
+
+    separator = "-+-".join("-" * width for width in widths)
+    lines = [render(headers), separator]
+    lines.extend(render(row) for row in rows)
+    return "\n".join(lines)
+
+
+def _truncate_rows(rows: list[list[str]], max_rows: int) -> tuple[list[list[str]], bool]:
+    if len(rows) <= max_rows:
+        return rows, False
+    head_count = max_rows // 2
+    tail_count = max_rows - head_count - 1
+    ellipsis_row = ["..."] * len(rows[0])
+    return rows[:head_count] + [ellipsis_row] + rows[-tail_count:], True
+
+
+def _resolve_ground_spec(ground_type: str, default_ground_type: str) -> str:
+    normalized = (ground_type or "").strip()
+    if not normalized or normalized.lower() == "default":
+        return default_ground_type
+    return normalized
+
+
+def _format_ground_display(ground_spec: str, default_ground_type: str = "average") -> str:
+    ground_name, epsilon_r, conductivity = parse_ground_spec(ground_spec, default_ground_type)
+    if ground_name == "custom" and epsilon_r is not None and conductivity is not None:
+        return f"custom (εr={epsilon_r:g}, σ={conductivity:g} S/m)"
+    if ground_name == "custom":
+        return "custom (backend defaults εr=13, σ=0.005 S/m)"
+    return ground_name
+
+
+def _parse_wire_design_string(text: str) -> list[WireGeometry]:
+    stripped = text.strip()
+    if not stripped:
+        raise ValueError(
+            "wires must be a semicolon-separated list of wire definitions in the form "
+            "'tag,segments,x1,y1,z1,x2,y2,z2,radius'."
+        )
+
+    entries = [entry.strip() for entry in stripped.replace("\n", ";").split(";") if entry.strip()]
+    if not entries:
+        raise ValueError("No wire definitions were provided.")
+
+    wires: list[WireGeometry] = []
+    for index, entry in enumerate(entries, start=1):
+        parts = [part.strip() for part in entry.split(",")]
+        if len(parts) != 9:
+            raise ValueError(
+                f"Wire {index} must have 9 comma-separated fields "
+                f"(tag,segments,x1,y1,z1,x2,y2,z2,radius); got {len(parts)} in {entry!r}."
+            )
+
+        try:
+            tag_value = float(parts[0])
+            segments_value = float(parts[1])
+            x1, y1, z1, x2, y2, z2, radius = (float(part) for part in parts[2:])
+        except ValueError as exc:
+            raise ValueError(f"Wire {index} contains non-numeric values: {entry!r}.") from exc
+
+        if not tag_value.is_integer() or tag_value <= 0:
+            raise ValueError(f"Wire {index} tag must be a positive integer; got {parts[0]!r}.")
+        if not segments_value.is_integer() or segments_value <= 0:
+            raise ValueError(f"Wire {index} segments must be a positive integer; got {parts[1]!r}.")
+        if int(segments_value) > 200:
+            raise ValueError(f"Wire {index} segments must be between 1 and 200; got {int(segments_value)}.")
+        if radius <= 0.0:
+            raise ValueError(f"Wire {index} radius must be greater than zero.")
+
+        numeric_values = (x1, y1, z1, x2, y2, z2, radius)
+        if not all(math.isfinite(value) for value in numeric_values):
+            raise ValueError(f"Wire {index} contains non-finite values.")
+
+        wires.append(
+            WireGeometry(
+                tag=int(tag_value),
+                segments=int(segments_value),
+                x1=x1,
+                y1=y1,
+                z1=z1,
+                x2=x2,
+                y2=y2,
+                z2=z2,
+                radius=radius,
+            )
+        )
+
+    return wires
+
+
+def _resolve_explicit_frequency_range(
+    freq_start_mhz: float,
+    freq_stop_mhz: float,
+    freq_steps: int,
+) -> FrequencyRange:
+    frequency_range = FrequencyRange(
+        start_mhz=float(freq_start_mhz),
+        stop_mhz=float(freq_stop_mhz),
+        steps=int(freq_steps),
+    )
+
+    if frequency_range.start_mhz < 0.1 or frequency_range.stop_mhz > 2000.0:
+        raise ValueError("Frequency limits must be between 0.1 and 2000 MHz.")
+    if frequency_range.stop_mhz < frequency_range.start_mhz:
+        raise ValueError("freq_stop_mhz must be greater than or equal to freq_start_mhz.")
+    if frequency_range.steps < 1 or frequency_range.steps > 201:
+        raise ValueError("freq_steps must be between 1 and 201.")
+
+    return frequency_range
+
+
+def _format_nec_value(value: float) -> str:
+    if not math.isfinite(value):
+        raise ValueError(f"NEC card values must be finite; got {value!r}.")
+    if math.isclose(value, 0.0, abs_tol=1e-12):
+        return "0"
+    text = f"{value:.9f}".rstrip("0").rstrip(".")
+    return "0" if text in {"-0", "+0"} else text
+
+
+def _extract_ground_constants(raw_value: Any) -> tuple[float | None, float | None]:
+    epsilon_r: Any = None
+    conductivity: Any = None
+
+    if isinstance(raw_value, Mapping):
+        for key in (
+            "epsilon_r",
+            "relative_permittivity",
+            "permittivity",
+            "dielectric_constant",
+            "dielectricConstant",
+            "epsr",
+            "er",
+        ):
+            if key in raw_value:
+                epsilon_r = raw_value[key]
+                break
+        for key in ("conductivity", "sigma", "conductivity_s_per_m", "cond"):
+            if key in raw_value:
+                conductivity = raw_value[key]
+                break
+    elif _is_non_string_sequence(raw_value):
+        items = list(raw_value)
+        if len(items) >= 2:
+            epsilon_r, conductivity = items[0], items[1]
+    else:
+        for attr in (
+            "epsilon_r",
+            "relative_permittivity",
+            "permittivity",
+            "dielectric_constant",
+            "dielectricConstant",
+            "epsr",
+            "er",
+        ):
+            if hasattr(raw_value, attr):
+                epsilon_r = getattr(raw_value, attr)
+                break
+        for attr in ("conductivity", "sigma", "conductivity_s_per_m", "cond"):
+            if hasattr(raw_value, attr):
+                conductivity = getattr(raw_value, attr)
+                break
+
+    if epsilon_r is None or conductivity is None:
+        return None, None
+
+    try:
+        epsilon_value = float(epsilon_r)
+        conductivity_value = float(conductivity)
+    except (TypeError, ValueError):
+        return None, None
+
+    if not math.isfinite(epsilon_value) or not math.isfinite(conductivity_value):
+        return None, None
+
+    return epsilon_value, conductivity_value
+
+
+def _ground_card(ground_spec: str, default_ground_type: str = "average") -> str:
+    ground_name, epsilon_r, conductivity = parse_ground_spec(ground_spec, default_ground_type)
+
+    if ground_name == "free_space":
+        return "GN -1"
+    if ground_name == "perfect":
+        return "GN 1"
+
+    if epsilon_r is None or conductivity is None:
+        raw_ground_value = GROUND_TYPE_VALUES.get(ground_name) if isinstance(GROUND_TYPE_VALUES, Mapping) else None
+        epsilon_r, conductivity = _extract_ground_constants(raw_ground_value)
+
+    if epsilon_r is None or conductivity is None:
+        epsilon_r, conductivity = 13.0, 0.005
+
+    return (
+        "GN 2 0 0 0 "
+        f"{_format_nec_value(float(epsilon_r))} {_format_nec_value(float(conductivity))}"
+    )
+
+
+def _build_nec2_card_deck(
+    wires: Sequence[Any],
+    excitation: Any | Sequence[Any],
+    frequency_range: FrequencyRange,
+    ground_spec: str,
+    comment_lines: Sequence[str] = (),
+    default_ground_type: str = "average",
+) -> str:
+    frequency_step = 0.0
+    if frequency_range.steps > 1:
+        frequency_step = (
+            (frequency_range.stop_mhz - frequency_range.start_mhz) / (frequency_range.steps - 1)
+        )
+
+    lines: list[str] = []
+    for comment in comment_lines:
+        text = str(comment).strip()
+        if text:
+            lines.append(f"CM {text}")
+
+    lines.append("CE")
+
+    for wire in wires:
+        lines.append(
+            "GW "
+            f"{int(_value(wire, 'tag'))} {int(_value(wire, 'segments'))} "
+            f"{_format_nec_value(float(_value(wire, 'x1')))} "
+            f"{_format_nec_value(float(_value(wire, 'y1')))} "
+            f"{_format_nec_value(float(_value(wire, 'z1')))} "
+            f"{_format_nec_value(float(_value(wire, 'x2')))} "
+            f"{_format_nec_value(float(_value(wire, 'y2')))} "
+            f"{_format_nec_value(float(_value(wire, 'z2')))} "
+            f"{_format_nec_value(float(_value(wire, 'radius')))}"
+        )
+
+    lines.append("GE 0")
+    lines.append(_ground_card(ground_spec, default_ground_type))
+
+    for item in _normalize_excitations(excitation):
+        lines.append(
+            "EX 0 "
+            f"{int(_value(item, 'wire_tag'))} {int(_value(item, 'segment'))} 0 "
+            f"{_format_nec_value(float(_value(item, 'voltage_real')))} "
+            f"{_format_nec_value(float(_value(item, 'voltage_imag')))}"
+        )
+
+    lines.append(
+        "FR 0 "
+        f"{int(frequency_range.steps)} 0 0 "
+        f"{_format_nec_value(float(frequency_range.start_mhz))} "
+        f"{_format_nec_value(float(frequency_step))}"
+    )
+    lines.append("RP 0 91 361 1000 0 0 1 1")
+    lines.append("EN")
+
+    return "\n".join(lines)
+
+
+def _resolve_frequency_range(
+    template: AntennaTemplate,
+    params: Mapping[str, float],
+    freq_start_mhz: float | None,
+    freq_stop_mhz: float | None,
+    freq_steps: int | None,
+) -> FrequencyRange:
+    default_range = template.default_frequency_range(params)
+    start = default_range.start_mhz if freq_start_mhz is None else float(freq_start_mhz)
+    stop = default_range.stop_mhz if freq_stop_mhz is None else float(freq_stop_mhz)
+    steps = default_range.steps if freq_steps is None or freq_steps <= 0 else int(freq_steps)
+
+    if start < 0.1 or stop < 0.1 or start > 2000.0 or stop > 2000.0:
+        raise ValueError("Frequency limits must be between 0.1 and 2000 MHz.")
+    if stop < start:
+        raise ValueError("freq_stop_mhz must be greater than or equal to freq_start_mhz.")
+    if steps < 1 or steps > 201:
+        raise ValueError("freq_steps must be between 1 and 201.")
+
+    return FrequencyRange(start_mhz=start, stop_mhz=stop, steps=steps)
+
+
+def _resolve_comparison_frequency_range(
+    template1: AntennaTemplate,
+    params1: Mapping[str, float],
+    template2: AntennaTemplate,
+    params2: Mapping[str, float],
+    freq_start_mhz: float | None,
+    freq_stop_mhz: float | None,
+    freq_steps: int | None,
+) -> FrequencyRange:
+    default1 = template1.default_frequency_range(params1)
+    default2 = template2.default_frequency_range(params2)
+
+    start = min(default1.start_mhz, default2.start_mhz) if freq_start_mhz is None else float(freq_start_mhz)
+    stop = max(default1.stop_mhz, default2.stop_mhz) if freq_stop_mhz is None else float(freq_stop_mhz)
+    steps = max(default1.steps, default2.steps) if freq_steps is None or freq_steps <= 0 else int(freq_steps)
+
+    if start < 0.1 or stop < 0.1 or start > 2000.0 or stop > 2000.0:
+        raise ValueError("Frequency limits must be between 0.1 and 2000 MHz.")
+    if stop < start:
+        raise ValueError("freq_stop_mhz must be greater than or equal to freq_start_mhz.")
+    if steps < 1 or steps > 201:
+        raise ValueError("freq_steps must be between 1 and 201.")
+
+    return FrequencyRange(start_mhz=start, stop_mhz=stop, steps=steps)
+
+
+def _geometry_summary(wires: Sequence[Any]) -> str:
+    xs: list[float] = []
+    ys: list[float] = []
+    zs: list[float] = []
+    total_segments = 0
+
+    for wire in wires:
+        total_segments += int(_value(wire, "segments"))
+        xs.extend([float(_value(wire, "x1")), float(_value(wire, "x2"))])
+        ys.extend([float(_value(wire, "y1")), float(_value(wire, "y2"))])
+        zs.extend([float(_value(wire, "z1")), float(_value(wire, "z2"))])
+
+    span_x = max(xs) - min(xs) if xs else 0.0
+    span_y = max(ys) - min(ys) if ys else 0.0
+    span_z = max(zs) - min(zs) if zs else 0.0
+
+    return (
+        f"{len(wires)} wires, {total_segments} total segments, "
+        f"span X={span_x:.3f} m, Y={span_y:.3f} m, Z={span_z:.3f} m"
+    )
+
+
+def _normalize_excitations(excitation: Any | Sequence[Any]) -> list[Any]:
+    if _is_non_string_sequence(excitation):
+        return list(excitation)
+    return [excitation]
+
+
+def _format_excitation_summary(excitation: Any | Sequence[Any]) -> str:
+    excitations = _normalize_excitations(excitation)
+    if len(excitations) == 1:
+        item = excitations[0]
+        return (
+            f"wire {_value(item, 'wire_tag')} segment {_value(item, 'segment')}, "
+            f"{float(_value(item, 'voltage_real')):.4f} + j{float(_value(item, 'voltage_imag')):.4f} V"
+        )
+
+    lines = []
+    for item in excitations:
+        lines.append(
+            f"- wire {_value(item, 'wire_tag')} segment {_value(item, 'segment')}, "
+            f"{float(_value(item, 'voltage_real')):.4f} + j{float(_value(item, 'voltage_imag')):.4f} V"
+        )
+    return "\n".join(lines)
+
+
+def _best_swr_result(frequency_data: Sequence[Any]) -> Any:
+    return min(frequency_data, key=lambda item: float(item.swr_50))
+
+
+def _peak_gain_result(frequency_data: Sequence[Any]) -> Any:
+    return max(frequency_data, key=lambda item: float(item.gain_max_dbi))
+
+
+def _best_front_to_back_result(frequency_data: Sequence[Any]) -> Any | None:
+    candidates = [item for item in frequency_data if item.front_to_back_db is not None]
+    if not candidates:
+        return None
+    return max(candidates, key=lambda item: float(item.front_to_back_db))
+
+
+def _average_efficiency(frequency_data: Sequence[Any]) -> float | None:
+    values = [float(item.efficiency_percent) for item in frequency_data if item.efficiency_percent is not None]
+    if not values:
+        return None
+    return sum(values) / len(values)
+
+
+def _nearest_frequency_result(frequency_data: Sequence[Any], target_mhz: float) -> Any:
+    return min(frequency_data, key=lambda item: abs(float(item.frequency_mhz) - target_mhz))
+
+
+def _beamwidth_summary(result: Any) -> str:
+    parts: list[str] = []
+    if result.beamwidth_e_deg is not None:
+        parts.append(f"E-plane {float(result.beamwidth_e_deg):.1f}°")
+    if result.beamwidth_h_deg is not None:
+        parts.append(f"H-plane {float(result.beamwidth_h_deg):.1f}°")
+    return ", ".join(parts) if parts else "—"
+
+
+def _count_usable_points(frequency_data: Sequence[Any], swr_threshold: float = 2.0) -> int:
+    return sum(1 for item in frequency_data if float(item.swr_50) <= swr_threshold)
+
+
+def _format_sweep_table(frequency_data: Sequence[Any], max_rows: int = 61) -> str:
+    rows = [
+        [
+            f"{float(item.frequency_mhz):.3f}",
+            f"{float(item.swr_50):.2f}",
+            f"{float(item.impedance.real):.2f}",
+            f"{float(item.impedance.imag):+.2f}",
+            f"{float(item.gain_max_dbi):.2f}",
+            f"{float(item.gain_max_theta):.1f}",
+            f"{float(item.gain_max_phi):.1f}",
+            "—" if item.front_to_back_db is None else f"{float(item.front_to_back_db):.2f}",
+            "—" if item.efficiency_percent is None else f"{float(item.efficiency_percent):.1f}",
+        ]
+        for item in frequency_data
+    ]
+    rows, truncated = _truncate_rows(rows, max_rows)
+    table = _format_table(
+        ["Freq MHz", "SWR", "R Ω", "X Ω", "Gain dBi", "Theta°", "Phi°", "F/B dB", "Eff %"],
+        rows,
+    )
+    if truncated:
+        return f"{table}\n\nNote: sweep table truncated for readability."
+    return table
+
+
+def _format_band_analysis_table(frequency_data: Sequence[Any], region: str = "r1") -> str:
+    analysis = [item for item in analyze_band_performance(frequency_data, region=region) if item.simulated]
+    if not analysis:
+        return ""
+
+    rows = [
+        [
+            item.band.label,
+            str(item.point_count),
+            "—" if item.min_swr is None else f"{item.min_swr:.2f}",
+            "—" if item.min_swr_freq_mhz is None else f"{item.min_swr_freq_mhz:.3f}",
+            "—" if item.usable_bandwidth_khz is None else str(item.usable_bandwidth_khz),
+            "—" if item.avg_gain_dbi is None else f"{item.avg_gain_dbi:.2f}",
+            "—" if item.peak_gain_dbi is None else f"{item.peak_gain_dbi:.2f}",
+            item.quality,
+        ]
+        for item in analysis
+    ]
+    return (
+        f"Band analysis (ITU {region.upper()})\n"
+        f"{_format_table(['Band', 'Points', 'Min SWR', 'At MHz', 'Usable kHz', 'Avg Gain', 'Peak Gain', 'Quality'], rows)}"
+    )
+
+
+def _run_template_simulation(
+    template_id: str,
+    params_json: str,
+    ground_type: str,
+    freq_start_mhz: float | None,
+    freq_stop_mhz: float | None,
+    freq_steps: int | None,
+) -> TemplateRun:
+    template = get_template(template_id)
+    params_data = _parse_json_object(params_json, "params")
+    params = resolve_params(template, params_data)
+    frequency_range = _resolve_frequency_range(template, params, freq_start_mhz, freq_stop_mhz, freq_steps)
+    ground_spec = _resolve_ground_spec(ground_type, template.default_ground.type)
+
+    wires = template.generate_geometry(params)
+    excitation = template.generate_excitation(params, wires)
+    artifacts = simulate(
+        wires=wires,
+        excitation=excitation,
+        frequency_range=frequency_range,
+        ground_type=ground_spec,
+        comment=f"{template.name} ({template.id}) via AntennaSim MCP",
+    )
+
+    return TemplateRun(
+        template=template,
+        params=params,
+        wires=wires,
+        excitation=excitation,
+        frequency_range=frequency_range,
+        ground_spec=ground_spec,
+        artifacts=artifacts,
+    )
+
+
+def _format_simulation_report(
+    title: str,
+    detail_lines: Sequence[str],
+    wires: Sequence[Any],
+    excitation: Any | Sequence[Any],
+    frequency_range: FrequencyRange,
+    ground_spec: str,
+    artifacts: SimulationArtifacts,
+) -> str:
+    frequency_data = artifacts.result.frequency_data
+    best_swr = _best_swr_result(frequency_data)
+    peak_gain = _peak_gain_result(frequency_data)
+    best_ftb = _best_front_to_back_result(frequency_data)
+    center_target = (float(frequency_data[0].frequency_mhz) + float(frequency_data[-1].frequency_mhz)) / 2.0
+    center_point = _nearest_frequency_result(frequency_data, center_target)
+    usable_points = _count_usable_points(frequency_data)
+    avg_eff = _average_efficiency(frequency_data)
+
+    lines: list[str] = [title, "=" * len(title), *detail_lines, ""]
+    lines.extend(
+        [
+            f"Ground: {_format_ground_display(ground_spec)}",
+            f"Sweep: {_format_frequency_range(frequency_range)}",
+            f"Geometry: {_geometry_summary(wires)}",
+            f"Excitation: {_format_excitation_summary(excitation)}",
+            f"Engine: {artifacts.result.engine}",
+            f"Simulation ID: {artifacts.result.simulation_id}",
+            f"Computed in: {float(artifacts.result.computed_in_ms):.1f} ms",
+            "",
+            "Key metrics",
+            f"- Best SWR(50Ω): {float(best_swr.swr_50):.2f} at {float(best_swr.frequency_mhz):.3f} MHz, Z = {_format_impedance(best_swr)}",
+            f"- Sweep points with SWR <= 2.0: {usable_points} of {len(frequency_data)}",
+            f"- Peak gain: {float(peak_gain.gain_max_dbi):.2f} dBi at {float(peak_gain.frequency_mhz):.3f} MHz "
+            f"(theta {float(peak_gain.gain_max_theta):.1f}°, phi {float(peak_gain.gain_max_phi):.1f}°, "
+            f"beamwidth {_beamwidth_summary(peak_gain)})",
+        ]
+    )
+
+    if best_ftb is not None:
+        lines.append(
+            f"- Best front-to-back: {float(best_ftb.front_to_back_db):.2f} dB at {float(best_ftb.frequency_mhz):.3f} MHz"
+        )
+    if avg_eff is not None:
+        lines.append(f"- Average efficiency: {avg_eff:.1f}%")
+    lines.append(
+        f"- Center-of-sweep point: {float(center_point.frequency_mhz):.3f} MHz, "
+        f"SWR {float(center_point.swr_50):.2f}, Z = {_format_impedance(center_point)}"
+    )
+
+    lines.extend(
+        [
+            "",
+            "Frequency sweep",
+            _format_sweep_table(frequency_data),
+        ]
+    )
+
+    band_section = _format_band_analysis_table(frequency_data, region="r1")
+    if band_section:
+        lines.extend(["", band_section])
+
+    if artifacts.result.warnings:
+        lines.extend(["", "Warnings"])
+        lines.extend(f"- {warning}" for warning in artifacts.result.warnings)
+
+    return "\n".join(lines).strip()
+
+
+def _winner_lower(value1: float | None, value2: float | None) -> str:
+    if value1 is None or value2 is None:
+        return "—"
+    if math.isclose(value1, value2, abs_tol=1e-9):
+        return "Tie"
+    return "Antenna 1" if value1 < value2 else "Antenna 2"
+
+
+def _winner_higher(value1: float | None, value2: float | None) -> str:
+    if value1 is None or value2 is None:
+        return "—"
+    if math.isclose(value1, value2, abs_tol=1e-9):
+        return "Tie"
+    return "Antenna 1" if value1 > value2 else "Antenna 2"
+
+
+def _format_comparison_report(run1: TemplateRun, run2: TemplateRun) -> str:
+    data1 = run1.artifacts.result.frequency_data
+    data2 = run2.artifacts.result.frequency_data
+
+    best1 = _best_swr_result(data1)
+    best2 = _best_swr_result(data2)
+    peak1 = _peak_gain_result(data1)
+    peak2 = _peak_gain_result(data2)
+    ftb1 = _best_front_to_back_result(data1)
+    ftb2 = _best_front_to_back_result(data2)
+    eff1 = _average_efficiency(data1)
+    eff2 = _average_efficiency(data2)
+    center_target = (run1.frequency_range.start_mhz + run1.frequency_range.stop_mhz) / 2.0
+    center1 = _nearest_frequency_result(data1, center_target)
+    center2 = _nearest_frequency_result(data2, center_target)
+    usable1 = _count_usable_points(data1)
+    usable2 = _count_usable_points(data2)
+
+    summary_rows = [
+        ["Geometry", f"{len(run1.wires)} wires / {run1.artifacts.result.total_segments} segs", f"{len(run2.wires)} wires / {run2.artifacts.result.total_segments} segs", "—"],
+        ["Best SWR", f"{float(best1.swr_50):.2f} @ {float(best1.frequency_mhz):.3f} MHz", f"{float(best2.swr_50):.2f} @ {float(best2.frequency_mhz):.3f} MHz", _winner_lower(float(best1.swr_50), float(best2.swr_50))],
+        ["Impedance @ best SWR", _format_impedance(best1), _format_impedance(best2), "—"],
+        ["Sweep points SWR <= 2.0", f"{usable1} of {len(data1)}", f"{usable2} of {len(data2)}", _winner_higher(float(usable1), float(usable2))],
+        ["Peak gain", f"{float(peak1.gain_max_dbi):.2f} dBi @ {float(peak1.frequency_mhz):.3f} MHz", f"{float(peak2.gain_max_dbi):.2f} dBi @ {float(peak2.frequency_mhz):.3f} MHz", _winner_higher(float(peak1.gain_max_dbi), float(peak2.gain_max_dbi))],
+        ["Peak F/B", "—" if ftb1 is None else f"{float(ftb1.front_to_back_db):.2f} dB", "—" if ftb2 is None else f"{float(ftb2.front_to_back_db):.2f} dB", _winner_higher(None if ftb1 is None else float(ftb1.front_to_back_db), None if ftb2 is None else float(ftb2.front_to_back_db))],
+        ["Beamwidth @ peak gain", _beamwidth_summary(peak1), _beamwidth_summary(peak2), "—"],
+        ["Average efficiency", "—" if eff1 is None else f"{eff1:.1f}%", "—" if eff2 is None else f"{eff2:.1f}%", _winner_higher(eff1, eff2)],
+        ["Center-of-sweep SWR", f"{float(center1.swr_50):.2f}", f"{float(center2.swr_50):.2f}", _winner_lower(float(center1.swr_50), float(center2.swr_50))],
+        ["Center-of-sweep impedance", _format_impedance(center1), _format_impedance(center2), "—"],
+    ]
+
+    lines = [
+        f"Comparison: {run1.template.name} vs {run2.template.name}",
+        "=" * (12 + len(run1.template.name) + len(run2.template.name)),
+        f"Antenna 1: {run1.template.name} ({run1.template.id})",
+        f"Antenna 1 params JSON: {json.dumps(run1.params)}",
+        f"Antenna 2: {run2.template.name} ({run2.template.id})",
+        f"Antenna 2 params JSON: {json.dumps(run2.params)}",
+        "",
+        f"Ground: {_format_ground_display(run1.ground_spec)}",
+        f"Sweep: {_format_frequency_range(run1.frequency_range)}",
+        "",
+        "Summary",
+        _format_table(["Metric", "Antenna 1", "Antenna 2", "Better"], summary_rows),
+    ]
+
+    same_grid = len(data1) == len(data2) and all(
+        math.isclose(float(item1.frequency_mhz), float(item2.frequency_mhz), abs_tol=1e-9)
+        for item1, item2 in zip(data1, data2)
+    )
+    if same_grid:
+        comparison_rows = [
+            [
+                f"{float(item1.frequency_mhz):.3f}",
+                f"{float(item1.swr_50):.2f}",
+                f"{float(item2.swr_50):.2f}",
+                f"{float(item1.gain_max_dbi):.2f}",
+                f"{float(item2.gain_max_dbi):.2f}",
+                _winner_lower(float(item1.swr_50), float(item2.swr_50)),
+                _winner_higher(float(item1.gain_max_dbi), float(item2.gain_max_dbi)),
+            ]
+            for item1, item2 in zip(data1, data2)
+        ]
+        comparison_rows, truncated = _truncate_rows(comparison_rows, 61)
+        lines.extend(
+            [
+                "",
+                "Per-frequency comparison",
+                _format_table(
+                    ["Freq MHz", "SWR 1", "SWR 2", "Gain 1", "Gain 2", "Lower SWR", "Higher Gain"],
+                    comparison_rows,
+                ),
+            ]
+        )
+        if truncated:
+            lines.append("\nNote: per-frequency comparison truncated for readability.")
+
+    if run1.artifacts.result.warnings:
+        lines.extend(["", "Warnings from Antenna 1"])
+        lines.extend(f"- {warning}" for warning in run1.artifacts.result.warnings)
+
+    if run2.artifacts.result.warnings:
+        lines.extend(["", "Warnings from Antenna 2"])
+        lines.extend(f"- {warning}" for warning in run2.artifacts.result.warnings)
+
+    return "\n".join(lines).strip()
+
+
+@mcp.tool()
+def list_antenna_templates() -> str:
+    """List all available antenna templates with IDs, categories, difficulty, and bands."""
+    try:
+        sections = [f"Available antenna templates ({len(TEMPLATES)} total)"]
+        category_order = ("wire", "vertical", "multiband", "loop", "directional")
+
+        for category in category_order:
+            group = [template for template in TEMPLATES if template.category == category]
+            if not group:
+                continue
+            sections.append("")
+            sections.append(f"[{category}]")
+            for template in group:
+                sections.append(
+                    f"- {template.id}: {template.name} | difficulty={template.difficulty} | bands={', '.join(template.bands)}"
+                )
+                sections.append(f"  {template.description}")
+
+        sections.append("")
+        sections.append("Use get_template_info(template_id) for full parameter details.")
+        return "\n".join(sections)
+    except Exception as exc:
+        return _format_exception(exc)
+
+
+@mcp.tool()
+def get_template_info(template_id: str) -> str:
+    """Return detailed information for one template, including parameters and defaults."""
+    try:
+        template = get_template(template_id)
+        default_params = template.get_default_params()
+        default_range = template.default_frequency_range(default_params)
+
+        lines = [
+            f"Template: {template.name} ({template.id})",
+            "=" * (11 + len(template.name) + len(template.id)),
+            f"Short name: {template.short_name}",
+            f"Category: {template.category}",
+            f"Difficulty: {template.difficulty}",
+            f"Typical bands: {', '.join(template.bands)}",
+            f"Default ground: {template.default_ground.type}",
+            f"Description: {template.description}",
+            "",
+            "Long description",
+            template.long_description,
+            "",
+            f"Default params JSON: {json.dumps(default_params)}",
+            f"Default sweep: {_format_frequency_range(default_range)}",
+            "",
+            "Parameters",
+        ]
+
+        for parameter in template.parameters:
+            default_text = _format_number(parameter.default_value, parameter.decimals)
+            range_min = _format_number(parameter.min, parameter.decimals)
+            range_max = _format_number(parameter.max, parameter.decimals)
+            step_text = _format_number(parameter.step, parameter.decimals)
+            unit_text = f" {parameter.unit}" if parameter.unit else ""
+            lines.append(
+                f"- {parameter.key}: {parameter.label}\n"
+                f"  Range: {range_min} to {range_max}{unit_text} | Step: {step_text}{unit_text} | "
+                f"Default: {default_text}{unit_text}\n"
+                f"  {parameter.description}"
+            )
+
+        lines.extend(["", "Tips"])
+        lines.extend(f"- {tip}" for tip in template.tips)
+
+        lines.extend(["", f"Related templates: {', '.join(template.related_templates)}"])
+        return "\n".join(lines)
+    except Exception as exc:
+        return _format_exception(exc)
+
+
+@mcp.tool()
+def list_ham_bands(region: str = "r1") -> str:
+    """List the ham bands defined for ITU region r1, r2, or r3."""
+    try:
+        normalized_region = region.strip().lower() or "r1"
+        bands = get_bands_for_region(normalized_region)  # type: ignore[arg-type]
+        rows = []
+        for band in bands:
+            freq_range = band_to_frequency_range(band)
+            rows.append(
+                [
+                    band.label,
+                    band.name,
+                    f"{band.start_mhz:.4f}",
+                    f"{band.stop_mhz:.4f}",
+                    f"{band.center_mhz:.4f}",
+                    str(freq_range["steps"]),
+                ]
+            )
+
+        return (
+            f"Ham bands for ITU {normalized_region.upper()}\n"
+            f"{_format_table(['Label', 'Name', 'Start MHz', 'Stop MHz', 'Center MHz', 'Suggested Sweep Points'], rows)}"
+        )
+    except Exception as exc:
+        return _format_exception(exc)
+
+
+@mcp.tool()
+def create_and_simulate_antenna(
+    template_id: str,
+    params: str = "",
+    ground_type: str = "average",
+    freq_start_mhz: float | None = None,
+    freq_stop_mhz: float | None = None,
+    freq_steps: int | None = None,
+) -> str:
+    """Create an antenna from a template and simulate it.
+
+    `params` must be a JSON object string, for example:
+    {"frequency": 14.1, "height": 10, "wire_diameter": 2.0}
+
+    `ground_type` may be a preset like "average" or a custom string like
+    "custom:13,0.005".
+    """
+    try:
+        run = _run_template_simulation(
+            template_id=template_id,
+            params_json=params,
+            ground_type=ground_type,
+            freq_start_mhz=freq_start_mhz,
+            freq_stop_mhz=freq_stop_mhz,
+            freq_steps=freq_steps,
+        )
+        return _format_simulation_report(
+            title=f"Simulation: {run.template.name}",
+            detail_lines=[
+                f"Template ID: {run.template.id}",
+                f"Description: {run.template.description}",
+                f"Resolved params JSON: {json.dumps(run.params)}",
+            ],
+            wires=run.wires,
+            excitation=run.excitation,
+            frequency_range=run.frequency_range,
+            ground_spec=run.ground_spec,
+            artifacts=run.artifacts,
+        )
+    except Exception as exc:
+        return _format_exception(exc)
+
+
+@mcp.tool()
+def compare_antennas(
+    antenna1_template: str,
+    antenna2_template: str,
+    antenna1_params: str = "",
+    antenna2_params: str = "",
+    freq_start_mhz: float | None = None,
+    freq_stop_mhz: float | None = None,
+    freq_steps: int | None = None,
+    ground_type: str = "average",
+) -> str:
+    """Simulate two template-based antennas on the same sweep and compare them."""
+    try:
+        template1 = get_template(antenna1_template)
+        template2 = get_template(antenna2_template)
+        params1 = resolve_params(template1, _parse_json_object(antenna1_params, "antenna1_params"))
+        params2 = resolve_params(template2, _parse_json_object(antenna2_params, "antenna2_params"))
+
+        frequency_range = _resolve_comparison_frequency_range(
+            template1,
+            params1,
+            template2,
+            params2,
+            freq_start_mhz,
+            freq_stop_mhz,
+            freq_steps,
+        )
+
+        ground_spec1 = _resolve_ground_spec(ground_type, template1.default_ground.type)
+        ground_spec2 = _resolve_ground_spec(ground_type, template2.default_ground.type)
+
+        wires1 = template1.generate_geometry(params1)
+        excitation1 = template1.generate_excitation(params1, wires1)
+        artifacts1 = simulate(
+            wires=wires1,
+            excitation=excitation1,
+            frequency_range=frequency_range,
+            ground_type=ground_spec1,
+            comment=f"{template1.name} comparison run via AntennaSim MCP",
+        )
+
+        wires2 = template2.generate_geometry(params2)
+        excitation2 = template2.generate_excitation(params2, wires2)
+        artifacts2 = simulate(
+            wires=wires2,
+            excitation=excitation2,
+            frequency_range=frequency_range,
+            ground_type=ground_spec2,
+            comment=f"{template2.name} comparison run via AntennaSim MCP",
+        )
+
+        run1 = TemplateRun(template1, params1, wires1, excitation1, frequency_range, ground_spec1, artifacts1)
+        run2 = TemplateRun(template2, params2, wires2, excitation2, frequency_range, ground_spec2, artifacts2)
+        return _format_comparison_report(run1, run2)
+    except Exception as exc:
+        return _format_exception(exc)
+
+
+@mcp.tool()
+def analyze_antenna_for_band(
+    template_id: str,
+    band: str,
+    params: str = "",
+    ground_type: str = "average",
+) -> str:
+    """Simulate one template specifically across a named ham band such as '20m'."""
+    try:
+        template = get_template(template_id)
+        band_spec = get_band_by_label(band, region="r1")
+        frequency_range = FrequencyRange(**band_to_frequency_range(band_spec))
+        resolved_params = resolve_params(template, _parse_json_object(params, "params"))
+        ground_spec = _resolve_ground_spec(ground_type, template.default_ground.type)
+
+        wires = template.generate_geometry(resolved_params)
+        excitation = template.generate_excitation(resolved_params, wires)
+        artifacts = simulate(
+            wires=wires,
+            excitation=excitation,
+            frequency_range=frequency_range,
+            ground_type=ground_spec,
+            comment=f"{template.name} band analysis for {band_spec.label}",
+        )
+
+        frequency_data = artifacts.result.frequency_data
+        center_result = _nearest_frequency_result(frequency_data, band_spec.center_mhz)
+        best_swr = _best_swr_result(frequency_data)
+        peak_gain = _peak_gain_result(frequency_data)
+        analyses = analyze_band_performance(frequency_data, region="r1")
+        performance = next(
+            (
+                item
+                for item in analyses
+                if item.band.label == band_spec.label
+                and math.isclose(item.band.start_mhz, band_spec.start_mhz, abs_tol=1e-9)
+                and math.isclose(item.band.stop_mhz, band_spec.stop_mhz, abs_tol=1e-9)
+            ),
+            None,
+        )
+
+        lines = [
+            f"Band analysis: {template.name} on {band_spec.label}",
+            "=" * (15 + len(template.name) + len(band_spec.label)),
+            f"Template ID: {template.id}",
+            f"Band definition (ITU R1): {band_spec.label} = {band_spec.start_mhz:.4f} to {band_spec.stop_mhz:.4f} MHz "
+            f"(center {band_spec.center_mhz:.4f} MHz)",
+            f"Resolved params JSON: {json.dumps(resolved_params)}",
+            f"Ground: {_format_ground_display(ground_spec)}",
+            f"Geometry: {_geometry_summary(wires)}",
+            f"Excitation: {_format_excitation_summary(excitation)}",
+            "",
+            "Band-specific metrics",
+            f"- Best SWR(50Ω): {float(best_swr.swr_50):.2f} at {float(best_swr.frequency_mhz):.3f} MHz, Z = {_format_impedance(best_swr)}",
+            f"- Center-of-band point: {float(center_result.frequency_mhz):.3f} MHz, SWR {float(center_result.swr_50):.2f}, Z = {_format_impedance(center_result)}",
+            f"- Peak gain in band: {float(peak_gain.gain_max_dbi):.2f} dBi at {float(peak_gain.frequency_mhz):.3f} MHz "
+            f"(theta {float(peak_gain.gain_max_theta):.1f}°, phi {float(peak_gain.gain_max_phi):.1f}°)",
+        ]
+
+        if performance is not None:
+            lines.extend(
+                [
+                    f"- Quality rating: {performance.quality}",
+                    f"- Simulated points in band: {performance.point_count}",
+                    f"- Average gain across band: {'—' if performance.avg_gain_dbi is None else f'{performance.avg_gain_dbi:.2f} dBi'}",
+                    f"- Usable bandwidth with SWR <= 2.0: "
+                    f"{'—' if performance.usable_bandwidth_khz is None else f'{performance.usable_bandwidth_khz} kHz'}",
+                ]
+            )
+
+        lines.extend(["", "Frequency sweep", _format_sweep_table(frequency_data)])
+
+        if artifacts.result.warnings:
+            lines.extend(["", "Warnings"])
+            lines.extend(f"- {warning}" for warning in artifacts.result.warnings)
+
+        return "\n".join(lines).strip()
+    except Exception as exc:
+        return _format_exception(exc)
+
+
+@mcp.tool()
+def simulate_custom_antenna(
+    wires_json: str,
+    excitation_json: str,
+    freq_start_mhz: float,
+    freq_stop_mhz: float,
+    freq_steps: int,
+    ground_type: str = "average",
+) -> str:
+    """Simulate arbitrary raw wire geometry.
+
+    `wires_json` must be a JSON array of wire objects matching the backend Wire model.
+    `excitation_json` may be a single excitation object or a list of excitations.
+    """
+    try:
+        wires = _parse_wires_json(wires_json)
+        excitation = _parse_excitations_json(excitation_json)
+        frequency_range = FrequencyRange(
+            start_mhz=float(freq_start_mhz),
+            stop_mhz=float(freq_stop_mhz),
+            steps=int(freq_steps),
+        )
+        if frequency_range.start_mhz < 0.1 or frequency_range.stop_mhz > 2000.0:
+            raise ValueError("Custom simulation frequency limits must be between 0.1 and 2000 MHz.")
+        if frequency_range.stop_mhz < frequency_range.start_mhz:
+            raise ValueError("freq_stop_mhz must be greater than or equal to freq_start_mhz.")
+        if frequency_range.steps < 1 or frequency_range.steps > 201:
+            raise ValueError("freq_steps must be between 1 and 201.")
+
+        artifacts = simulate(
+            wires=wires,
+            excitation=excitation,
+            frequency_range=frequency_range,
+            ground_type=ground_type,
+            comment="Custom antenna geometry via AntennaSim MCP",
+        )
+
+        return _format_simulation_report(
+            title="Simulation: Custom Antenna",
+            detail_lines=[
+                "Source: raw wires_json / excitation_json input",
+                f"Ground type input: {ground_type}",
+            ],
+            wires=wires,
+            excitation=excitation,
+            frequency_range=frequency_range,
+            ground_spec=ground_type,
+            artifacts=artifacts,
+        )
+    except Exception as exc:
+        return _format_exception(exc)
+
+
+@mcp.tool()
+def design_wire_antenna(
+    wires: str,
+    feed_wire_tag: int,
+    feed_segment: int,
+    freq_start_mhz: float,
+    freq_stop_mhz: float,
+    freq_steps: int = 31,
+    ground_type: str = "average",
+    antenna_name: str = "Custom design",
+) -> str:
+    """Simulate a custom wire antenna from a compact semicolon-separated wire list.
+
+    Each wire must be:
+    "tag,segments,x1,y1,z1,x2,y2,z2,radius"
+
+    Coordinates and radius are in meters.
+    Example:
+    "1,21,0,0,10,-5,0,10,0.001;2,21,0,0,10,5,0,10,0.001"
+    """
+    try:
+        if feed_wire_tag <= 0:
+            raise ValueError("feed_wire_tag must be a positive integer.")
+        if feed_segment <= 0:
+            raise ValueError("feed_segment must be a positive integer.")
+
+        parsed_wires = _parse_wire_design_string(wires)
+        feed_matches = [wire for wire in parsed_wires if wire.tag == feed_wire_tag]
+        if not feed_matches:
+            raise ValueError(f"feed_wire_tag {feed_wire_tag} does not match any wire tag in the design.")
+        if len(feed_matches) > 1:
+            raise ValueError(
+                f"feed_wire_tag {feed_wire_tag} matches multiple wires. "
+                "Use unique wire tags with design_wire_antenna."
+            )
+
+        feed_wire = feed_matches[0]
+        if feed_segment > feed_wire.segments:
+            raise ValueError(
+                f"feed_segment {feed_segment} is out of range for wire {feed_wire_tag}; "
+                f"that wire has {feed_wire.segments} segments."
+            )
+
+        frequency_range = _resolve_explicit_frequency_range(freq_start_mhz, freq_stop_mhz, freq_steps)
+        ground_spec = _resolve_ground_spec(ground_type, "average")
+        title = (antenna_name or "").strip() or "Custom design"
+        excitation = Excitation(
+            wire_tag=feed_wire_tag,
+            segment=feed_segment,
+            voltage_real=1.0,
+            voltage_imag=0.0,
+        )
+
+        artifacts = simulate(
+            wires=parsed_wires,
+            excitation=excitation,
+            frequency_range=frequency_range,
+            ground_type=ground_spec,
+            comment=f"{title} via AntennaSim MCP",
+        )
+
+        return _format_simulation_report(
+            title=f"Simulation: {title}",
+            detail_lines=[
+                "Source: design_wire_antenna wire list input",
+                f"Feed: wire {feed_wire_tag}, segment {feed_segment}",
+                f"Parsed wires: {len(parsed_wires)}",
+            ],
+            wires=parsed_wires,
+            excitation=excitation,
+            frequency_range=frequency_range,
+            ground_spec=ground_spec,
+            artifacts=artifacts,
+        )
+    except Exception as exc:
+        return _format_exception(exc)
+
+
+@mcp.tool()
+def get_nec2_card_deck(
+    template_id: str,
+    params: str = "",
+    ground_type: str = "average",
+    freq_start_mhz: float | None = None,
+    freq_stop_mhz: float | None = None,
+    freq_steps: int | None = None,
+) -> str:
+    """Return the raw NEC2 card deck for a template configuration without running nec2c."""
+    try:
+        template = get_template(template_id)
+        resolved_params = resolve_params(template, _parse_json_object(params, "params"))
+        frequency_range = _resolve_frequency_range(
+            template,
+            resolved_params,
+            freq_start_mhz,
+            freq_stop_mhz,
+            freq_steps,
+        )
+        ground_spec = _resolve_ground_spec(ground_type, template.default_ground.type)
+
+        wires = template.generate_geometry(resolved_params)
+        excitation = template.generate_excitation(resolved_params, wires)
+
+        return _build_nec2_card_deck(
+            wires=wires,
+            excitation=excitation,
+            frequency_range=frequency_range,
+            ground_spec=ground_spec,
+            comment_lines=(
+                f"{template.name} ({template.id}) via AntennaSim MCP",
+                f"params={json.dumps(resolved_params, sort_keys=True, separators=(',', ':'))}",
+                f"ground={ground_spec} sweep={frequency_range.start_mhz:.3f}-{frequency_range.stop_mhz:.3f}MHz steps={frequency_range.steps}",
+            ),
+            default_ground_type=template.default_ground.type,
+        )
+    except Exception as exc:
+        return _format_exception(exc)
+
+
+def main() -> None:
+    """Run the MCP server using stdio transport."""
+    mcp.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/mcp/simulator.py
+++ b/mcp/simulator.py
@@ -1,0 +1,424 @@
+"""High-level NEC2 simulation wrapper for the MCP server.
+
+This module adds the AntennaSim backend to sys.path, imports the backend's
+models and NEC helpers directly, and exposes a simple `simulate()` function.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import importlib
+import os
+import sys
+import time
+import uuid
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+GROUND_TYPE_VALUES: tuple[str, ...] = (
+    "free_space",
+    "perfect",
+    "salt_water",
+    "fresh_water",
+    "pastoral",
+    "average",
+    "rocky",
+    "city",
+    "dry_sandy",
+    "custom",
+)
+
+
+class BackendImportError(RuntimeError):
+    """Raised when the AntennaSim backend cannot be located or imported."""
+
+
+class SimulationError(RuntimeError):
+    """Raised when simulation setup, execution, or parsing fails."""
+
+
+class NecNotFoundError(SimulationError):
+    """Raised when nec2c is not available on PATH."""
+
+
+@dataclass(slots=True)
+class BackendAPI:
+    """Lazy-imported backend API references."""
+
+    Wire: Any
+    Excitation: Any
+    GroundConfig: Any
+    GroundType: Any
+    FrequencyConfig: Any
+    PatternConfig: Any
+    NearFieldConfig: Any
+    SimulationRequest: Any
+    SimulationResult: Any
+    build_card_deck: Any
+    run_nec2c: Any
+    parse_nec_output: Any
+    parse_near_field_output: Any
+    NecExecutionError: type[Exception]
+    backend_dir: Path
+
+
+@dataclass(slots=True)
+class SimulationArtifacts:
+    """All useful outputs from a simulation run."""
+
+    request: Any
+    card_deck: str
+    raw_output: str
+    result: Any
+    backend_dir: Path
+
+
+_BACKEND_API: BackendAPI | None = None
+
+
+def _candidate_backend_dirs() -> list[Path]:
+    env_dir = os.environ.get("ANTENNASIM_BACKEND_DIR", "").strip()
+    here = Path(__file__).resolve()
+    candidates: list[Path] = []
+
+    if env_dir:
+        candidates.append(Path(env_dir))
+
+    candidates.extend(
+        [
+            here.parents[1] / "backend",
+            here.parents[2] / "backend",
+            Path.cwd() / "backend",
+            Path.cwd() / "AntennaSim" / "backend",
+        ]
+    )
+
+    unique: list[Path] = []
+    seen: set[Path] = set()
+    for candidate in candidates:
+        resolved = candidate.expanduser().resolve()
+        if resolved in seen:
+            continue
+        seen.add(resolved)
+        unique.append(resolved)
+    return unique
+
+
+def _find_backend_dir() -> Path:
+    for candidate in _candidate_backend_dirs():
+        if (candidate / "src" / "models").is_dir():
+            return candidate
+    searched = "\n".join(f"- {path}" for path in _candidate_backend_dirs())
+    raise BackendImportError(
+        "Could not locate AntennaSim/backend.\n"
+        "Expected a backend directory containing src/models.\n"
+        "Searched:\n"
+        f"{searched}\n"
+        "Set ANTENNASIM_BACKEND_DIR to the AntennaSim/backend directory if needed."
+    )
+
+
+def load_backend_api() -> BackendAPI:
+    """Locate and import the AntennaSim backend lazily."""
+    global _BACKEND_API
+
+    if _BACKEND_API is not None:
+        return _BACKEND_API
+
+    backend_dir = _find_backend_dir()
+    backend_path = str(backend_dir)
+    if backend_path not in sys.path:
+        sys.path.insert(0, backend_path)
+
+    try:
+        antenna_module = importlib.import_module("src.models.antenna")
+        ground_module = importlib.import_module("src.models.ground")
+        simulation_models = importlib.import_module("src.models.simulation")
+        result_models = importlib.import_module("src.models.results")
+        nec_input_module = importlib.import_module("src.simulation.nec_input")
+        nec_runner_module = importlib.import_module("src.simulation.nec_runner")
+        nec_output_module = importlib.import_module("src.simulation.nec_output")
+    except ModuleNotFoundError as exc:
+        raise BackendImportError(
+            f"Failed to import backend modules from {backend_dir}. "
+            "Ensure dependencies are installed and ANTENNASIM_BACKEND_DIR is correct."
+        ) from exc
+
+    _BACKEND_API = BackendAPI(
+        Wire=antenna_module.Wire,
+        Excitation=antenna_module.Excitation,
+        GroundConfig=ground_module.GroundConfig,
+        GroundType=ground_module.GroundType,
+        FrequencyConfig=simulation_models.FrequencyConfig,
+        PatternConfig=simulation_models.PatternConfig,
+        NearFieldConfig=simulation_models.NearFieldConfig,
+        SimulationRequest=simulation_models.SimulationRequest,
+        SimulationResult=result_models.SimulationResult,
+        build_card_deck=nec_input_module.build_card_deck,
+        run_nec2c=nec_runner_module.run_nec2c,
+        parse_nec_output=nec_output_module.parse_nec_output,
+        parse_near_field_output=nec_output_module.parse_near_field_output,
+        NecExecutionError=nec_runner_module.NecExecutionError,
+        backend_dir=backend_dir,
+    )
+    return _BACKEND_API
+
+
+def parse_ground_spec(
+    ground_type: str | None,
+    default_ground_type: str = "average",
+) -> tuple[str, float | None, float | None]:
+    """Parse a ground preset string.
+
+    Accepted forms:
+    - "average"
+    - "salt_water"
+    - "custom"
+    - "custom:13,0.005"  -> epsilon_r=13, conductivity=0.005 S/m
+    """
+    raw = (ground_type or "").strip()
+    if not raw or raw.lower() == "default":
+        return default_ground_type, None, None
+
+    lowered = raw.lower()
+
+    if lowered.startswith("custom:"):
+        body = raw.split(":", 1)[1]
+        parts = [part.strip() for part in body.split(",")]
+        if len(parts) != 2:
+            raise ValueError(
+                "Custom ground must be formatted as 'custom:epsilon_r,conductivity', "
+                "for example 'custom:13,0.005'."
+            )
+        try:
+            epsilon_r = float(parts[0])
+            conductivity = float(parts[1])
+        except ValueError as exc:
+            raise ValueError(
+                "Custom ground values must be numeric, e.g. 'custom:13,0.005'."
+            ) from exc
+        return "custom", epsilon_r, conductivity
+
+    normalized = lowered.replace("-", "_").replace(" ", "_")
+    if normalized not in GROUND_TYPE_VALUES:
+        valid = ", ".join(GROUND_TYPE_VALUES)
+        raise ValueError(
+            f"Unknown ground type {ground_type!r}. Valid presets: {valid}. "
+            "You may also use 'custom:epsilon_r,conductivity'."
+        )
+    return normalized, None, None
+
+
+def _is_non_string_sequence(value: Any) -> bool:
+    return isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray, Mapping))
+
+
+def _coerce_payload(value: Any) -> dict[str, Any]:
+    if isinstance(value, Mapping):
+        return dict(value)
+    if dataclasses.is_dataclass(value):
+        return dataclasses.asdict(value)
+    if hasattr(value, "model_dump"):
+        return dict(value.model_dump())
+    if hasattr(value, "__dict__"):
+        return dict(vars(value))
+    raise TypeError(f"Cannot convert {type(value).__name__} to a payload dictionary.")
+
+
+def _coerce_mapping(value: Any, required_fields: Sequence[str]) -> dict[str, Any]:
+    if isinstance(value, Mapping):
+        payload = dict(value)
+    elif dataclasses.is_dataclass(value):
+        payload = dataclasses.asdict(value)
+    elif hasattr(value, "model_dump"):
+        payload = dict(value.model_dump())
+    else:
+        payload = {}
+        missing_fields: list[str] = []
+        for field_name in required_fields:
+            if hasattr(value, field_name):
+                payload[field_name] = getattr(value, field_name)
+            else:
+                missing_fields.append(field_name)
+        if missing_fields:
+            raise TypeError(
+                f"Object of type {type(value).__name__} is missing fields: {', '.join(missing_fields)}"
+            )
+
+    missing = [field_name for field_name in required_fields if field_name not in payload]
+    if missing:
+        raise ValueError(f"Missing required field(s): {', '.join(missing)}")
+    return payload
+
+
+def _extract_warnings(output: str) -> list[str]:
+    warnings: list[str] = []
+    seen: set[str] = set()
+
+    for line in output.splitlines():
+        text = " ".join(line.split())
+        if not text:
+            continue
+        upper = text.upper()
+        if "WARNING" in upper or upper.startswith("NOTE"):
+            if text not in seen:
+                warnings.append(text)
+                seen.add(text)
+    return warnings
+
+
+def _build_ground_config(
+    api: BackendAPI,
+    ground_type: str,
+    dielectric_constant: float | None = None,
+    conductivity: float | None = None,
+) -> Any:
+    parsed_ground_type, parsed_eps, parsed_sigma = parse_ground_spec(ground_type)
+
+    if dielectric_constant is None:
+        dielectric_constant = parsed_eps
+    if conductivity is None:
+        conductivity = parsed_sigma
+
+    try:
+        ground_enum = api.GroundType(parsed_ground_type)
+    except ValueError as exc:
+        valid = ", ".join(GROUND_TYPE_VALUES)
+        raise ValueError(
+            f"Unknown ground type {parsed_ground_type!r}. Valid presets: {valid}"
+        ) from exc
+
+    kwargs: dict[str, Any] = {"ground_type": ground_enum}
+    if parsed_ground_type == "custom":
+        if dielectric_constant is not None:
+            kwargs["dielectric_constant"] = dielectric_constant
+        if conductivity is not None:
+            kwargs["conductivity"] = conductivity
+
+    return api.GroundConfig(**kwargs)
+
+
+def simulate(
+    wires: Sequence[Any],
+    excitation: Any | Sequence[Any],
+    frequency_range: Any,
+    ground_type: str = "average",
+    pattern: Mapping[str, Any] | None = None,
+    comment: str = "AntennaSim MCP simulation",
+    compute_currents: bool = False,
+    near_field: Mapping[str, Any] | None = None,
+    loads: Sequence[Any] | None = None,
+    transmission_lines: Sequence[Any] | None = None,
+    dielectric_constant: float | None = None,
+    conductivity: float | None = None,
+) -> SimulationArtifacts:
+    """Build a backend SimulationRequest, run nec2c, parse, and return artifacts."""
+    api = load_backend_api()
+
+    wire_fields = ("tag", "segments", "x1", "y1", "z1", "x2", "y2", "z2", "radius")
+    excitation_fields = ("wire_tag", "segment", "voltage_real", "voltage_imag")
+    frequency_fields = ("start_mhz", "stop_mhz", "steps")
+
+    wire_objects = [api.Wire(**_coerce_mapping(wire, wire_fields)) for wire in wires]
+
+    excitation_items = list(excitation) if _is_non_string_sequence(excitation) else [excitation]
+    excitation_objects = [
+        api.Excitation(**_coerce_mapping(item, excitation_fields))
+        for item in excitation_items
+    ]
+
+    frequency_object = api.FrequencyConfig(**_coerce_mapping(frequency_range, frequency_fields))
+    pattern_object = api.PatternConfig(**(_coerce_payload(pattern) if pattern is not None else {}))
+    near_field_object = (
+        api.NearFieldConfig(**_coerce_payload(near_field)) if near_field is not None else None
+    )
+
+    load_payloads = [_coerce_payload(item) for item in (loads or [])]
+    transmission_payloads = [_coerce_payload(item) for item in (transmission_lines or [])]
+
+    request = api.SimulationRequest(
+        wires=wire_objects,
+        excitations=excitation_objects,
+        ground=_build_ground_config(
+            api,
+            ground_type=ground_type,
+            dielectric_constant=dielectric_constant,
+            conductivity=conductivity,
+        ),
+        frequency=frequency_object,
+        pattern=pattern_object,
+        comment=comment,
+        loads=load_payloads,
+        transmission_lines=transmission_payloads,
+        compute_currents=compute_currents,
+        near_field=near_field_object,
+    )
+
+    card_deck = api.build_card_deck(request)
+
+    started = time.perf_counter()
+    try:
+        raw_output = api.run_nec2c(card_deck)
+    except FileNotFoundError as exc:
+        raise NecNotFoundError(
+            "nec2c executable not found. Install nec2c and ensure it is on PATH."
+        ) from exc
+    except api.NecExecutionError as exc:
+        raise SimulationError(f"nec2c execution failed: {exc}") from exc
+    elapsed_ms = (time.perf_counter() - started) * 1000.0
+
+    frequency_data = api.parse_nec_output(
+        raw_output,
+        request.pattern.n_theta,
+        request.pattern.n_phi,
+        request.pattern.theta_start,
+        request.pattern.theta_step,
+        request.pattern.phi_start,
+        request.pattern.phi_step,
+        compute_currents=compute_currents,
+    )
+    if not frequency_data:
+        raise SimulationError("nec2c completed, but no frequency data could be parsed from the output.")
+
+    near_field_result = None
+    if request.near_field and request.near_field.enabled:
+        near_field_result = api.parse_near_field_output(
+            raw_output,
+            plane=request.near_field.plane,
+            height_m=request.near_field.height_m,
+            extent_m=request.near_field.extent_m,
+            resolution_m=request.near_field.resolution_m,
+        )
+
+    result = api.SimulationResult(
+        simulation_id=uuid.uuid4().hex[:12],
+        engine="nec2c",
+        computed_in_ms=round(elapsed_ms, 3),
+        total_segments=sum(wire.segments for wire in request.wires),
+        cached=False,
+        frequency_data=frequency_data,
+        near_field=near_field_result,
+        warnings=_extract_warnings(raw_output),
+    )
+
+    return SimulationArtifacts(
+        request=request,
+        card_deck=card_deck,
+        raw_output=raw_output,
+        result=result,
+        backend_dir=api.backend_dir,
+    )
+
+
+__all__ = [
+    "BackendImportError",
+    "GROUND_TYPE_VALUES",
+    "NecNotFoundError",
+    "SimulationArtifacts",
+    "SimulationError",
+    "load_backend_api",
+    "parse_ground_spec",
+    "simulate",
+]

--- a/mcp/templates.py
+++ b/mcp/templates.py
@@ -1,0 +1,2033 @@
+"""Antenna template registry and geometry generators.
+
+Ported from the frontend TypeScript template system with matching formulas.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import Any, Callable, Literal, Mapping
+
+TemplateCategory = Literal["wire", "vertical", "directional", "loop", "multiband"]
+TemplateDifficulty = Literal["beginner", "intermediate", "advanced"]
+GroundTypeName = Literal[
+    "free_space",
+    "perfect",
+    "salt_water",
+    "fresh_water",
+    "pastoral",
+    "average",
+    "rocky",
+    "city",
+    "dry_sandy",
+    "custom",
+]
+
+
+@dataclass(frozen=True, slots=True)
+class ParameterDef:
+    """Template slider/input definition."""
+
+    key: str
+    label: str
+    description: str
+    unit: str
+    min: float
+    max: float
+    step: float
+    default_value: float
+    decimals: int | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class GroundPreset:
+    """Default ground configuration for a template."""
+
+    type: GroundTypeName
+    custom_permittivity: float | None = None
+    custom_conductivity: float | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class WireGeometry:
+    """A single NEC2 wire geometry record."""
+
+    tag: int
+    segments: int
+    x1: float
+    y1: float
+    z1: float
+    x2: float
+    y2: float
+    z2: float
+    radius: float
+
+
+@dataclass(frozen=True, slots=True)
+class Excitation:
+    """A voltage source excitation."""
+
+    wire_tag: int
+    segment: int
+    voltage_real: float
+    voltage_imag: float
+
+
+@dataclass(frozen=True, slots=True)
+class FrequencyRange:
+    """Default sweep configuration."""
+
+    start_mhz: float
+    stop_mhz: float
+    steps: int
+
+
+@dataclass(frozen=True, slots=True)
+class ArcGeometry:
+    """Arc definition mirroring the frontend helper."""
+
+    tag: int
+    segments: int
+    arc_radius: float
+    start_angle: float
+    end_angle: float
+    wire_radius: float
+
+
+@dataclass(frozen=True, slots=True)
+class AntennaTemplate:
+    """Complete antenna template definition."""
+
+    id: str
+    name: str
+    short_name: str
+    description: str
+    long_description: str
+    icon: str
+    category: TemplateCategory
+    difficulty: TemplateDifficulty
+    bands: tuple[str, ...]
+    parameters: tuple[ParameterDef, ...]
+    default_ground: GroundPreset
+    generate_geometry: Callable[[Mapping[str, float]], list[WireGeometry]]
+    generate_excitation: Callable[[Mapping[str, float], list[WireGeometry]], Excitation]
+    default_frequency_range: Callable[[Mapping[str, float]], FrequencyRange]
+    tips: tuple[str, ...]
+    related_templates: tuple[str, ...]
+
+    def get_default_params(self) -> dict[str, float]:
+        """Return the default parameter values for this template."""
+        return {parameter.key: parameter.default_value for parameter in self.parameters}
+
+
+class TemplateNotFoundError(ValueError):
+    """Raised when a template ID cannot be resolved."""
+
+
+class TemplateParameterError(ValueError):
+    """Raised when template parameters are invalid."""
+
+
+def _parameter(
+    key: str,
+    label: str,
+    description: str,
+    unit: str,
+    minimum: float,
+    maximum: float,
+    step: float,
+    default_value: float,
+    decimals: int | None = None,
+) -> ParameterDef:
+    return ParameterDef(
+        key=key,
+        label=label,
+        description=description,
+        unit=unit,
+        min=minimum,
+        max=maximum,
+        step=step,
+        default_value=default_value,
+        decimals=decimals,
+    )
+
+
+def _param(params: Mapping[str, float], key: str, default: float) -> float:
+    value = params.get(key, default)
+    if value is None:
+        return default
+    return float(value)
+
+
+def auto_segment(wire_length_m: float, max_freq_mhz: float, min_segs: int = 5) -> int:
+    """Port of frontend/src/engine/segmentation.ts autoSegment()."""
+    wavelength = 300.0 / max_freq_mhz
+    seg_length = wavelength / 10.0
+    n = max(min_segs, math.ceil(wire_length_m / seg_length))
+    if n % 2 == 0:
+        n += 1
+    return min(n, 200)
+
+
+def center_segment(total_segments: int) -> int:
+    """Port of frontend/src/engine/segmentation.ts centerSegment()."""
+    return math.ceil(total_segments / 2)
+
+
+def arc_to_wire_segments(arc: ArcGeometry, center_height: float = 0.0) -> list[WireGeometry]:
+    """Convert an arc to straight wire segments like the frontend helper."""
+    wires: list[WireGeometry] = []
+    start_rad = (arc.start_angle * math.pi) / 180.0
+    end_rad = (arc.end_angle * math.pi) / 180.0
+    total_angle = end_rad - start_rad
+    num_segs = arc.segments
+    angle_step = total_angle / num_segs
+
+    for i in range(num_segs):
+        a1 = start_rad + i * angle_step
+        a2 = start_rad + (i + 1) * angle_step
+        wires.append(
+            WireGeometry(
+                tag=arc.tag,
+                segments=1,
+                x1=arc.arc_radius * math.cos(a1),
+                y1=0.0,
+                z1=arc.arc_radius * math.sin(a1) + center_height,
+                x2=arc.arc_radius * math.cos(a2),
+                y2=0.0,
+                z2=arc.arc_radius * math.sin(a2) + center_height,
+                radius=arc.wire_radius,
+            )
+        )
+    return wires
+
+
+def _centered_frequency_range(
+    frequency_mhz: float,
+    total_bandwidth_fraction: float,
+    steps: int,
+) -> FrequencyRange:
+    bandwidth = frequency_mhz * total_bandwidth_fraction
+    return FrequencyRange(
+        start_mhz=max(0.1, frequency_mhz - bandwidth / 2.0),
+        stop_mhz=min(2000.0, frequency_mhz + bandwidth / 2.0),
+        steps=steps,
+    )
+
+
+AVERAGE_GROUND = GroundPreset(type="average")
+
+
+# ---------------------------------------------------------------------------
+# Dipole
+# ---------------------------------------------------------------------------
+
+def _dipole_geometry(params: Mapping[str, float]) -> list[WireGeometry]:
+    freq = _param(params, "frequency", 14.1)
+    height = _param(params, "height", 10.0)
+    wire_diam_mm = _param(params, "wire_diameter", 2.0)
+
+    wavelength = 300.0 / freq
+    half_length = (wavelength / 2.0) * 0.95 / 2.0
+    radius = (wire_diam_mm / 1000.0) / 2.0
+
+    max_freq = freq * 1.15
+    segs_per_arm = auto_segment(half_length, max_freq, 11)
+
+    return [
+        WireGeometry(1, segs_per_arm, -half_length, 0.0, height, 0.0, 0.0, height, radius),
+        WireGeometry(2, segs_per_arm, 0.0, 0.0, height, half_length, 0.0, height, radius),
+    ]
+
+
+def _dipole_excitation(_params: Mapping[str, float], wires: list[WireGeometry]) -> Excitation:
+    wire1 = wires[0]
+    return Excitation(wire_tag=wire1.tag, segment=wire1.segments, voltage_real=1.0, voltage_imag=0.0)
+
+
+def _dipole_frequency_range(params: Mapping[str, float]) -> FrequencyRange:
+    freq = _param(params, "frequency", 14.1)
+    return _centered_frequency_range(freq, 0.1, 31)
+
+
+dipole_template = AntennaTemplate(
+    id="dipole",
+    name="Half-Wave Dipole",
+    short_name="Dipole",
+    description="Classic half-wave dipole — the fundamental antenna for any band.",
+    long_description=(
+        "A half-wave dipole consists of two equal-length wires fed at the center. "
+        "Total length is approximately one-half wavelength at the design frequency. "
+        "It produces a figure-8 pattern in the horizontal plane with ~2.15 dBi gain. "
+        "The feed impedance at resonance is approximately 73 ohms in free space, "
+        "varying with height above ground. This is the reference antenna for all other designs."
+    ),
+    icon="—|—",
+    category="wire",
+    difficulty="beginner",
+    bands=("160m", "80m", "40m", "20m", "15m", "10m", "6m", "2m"),
+    parameters=(
+        _parameter("frequency", "Design Frequency", "Center frequency for half-wave resonance", "MHz", 0.5, 2000.0, 0.1, 14.1, 3),
+        _parameter("height", "Height", "Height above ground at the feed point", "m", 0.5, 100.0, 0.5, 10.0, 1),
+        _parameter("wire_diameter", "Wire Diameter", "Conductor diameter", "mm", 0.5, 10.0, 0.1, 2.0, 1),
+    ),
+    default_ground=AVERAGE_GROUND,
+    generate_geometry=_dipole_geometry,
+    generate_excitation=_dipole_excitation,
+    default_frequency_range=_dipole_frequency_range,
+    tips=(
+        "Height above ground significantly affects impedance and pattern.",
+        "At λ/2 height, gain maximizes at low angles — ideal for DX.",
+        "At λ/4 height, the pattern tilts upward — better for NVIS.",
+        "Use thicker wire (larger diameter) for broader SWR bandwidth.",
+        "Resonant frequency is slightly lower than the formula λ/2 due to end effects.",
+    ),
+    related_templates=("inverted-v", "fan-dipole", "off-center-fed"),
+)
+
+
+# ---------------------------------------------------------------------------
+# Inverted V
+# ---------------------------------------------------------------------------
+
+def _inverted_v_geometry(params: Mapping[str, float]) -> list[WireGeometry]:
+    freq = _param(params, "frequency", 7.1)
+    apex_height = _param(params, "apex_height", 12.0)
+    included_angle = _param(params, "included_angle", 120.0)
+    wire_diam_mm = _param(params, "wire_diameter", 2.0)
+
+    wavelength = 300.0 / freq
+    arm_length = (wavelength / 2.0) * 0.95 / 2.0
+    radius = (wire_diam_mm / 1000.0) / 2.0
+
+    half_angle = (included_angle / 2.0) * (math.pi / 180.0)
+    horiz_extent = arm_length * math.sin(half_angle)
+    vert_drop = arm_length * math.cos(half_angle)
+    end_height = apex_height - vert_drop
+
+    max_freq = freq * 1.15
+    segs_per_arm = auto_segment(arm_length, max_freq, 11)
+
+    return [
+        WireGeometry(1, segs_per_arm, -horiz_extent, 0.0, end_height, 0.0, 0.0, apex_height, radius),
+        WireGeometry(2, segs_per_arm, 0.0, 0.0, apex_height, horiz_extent, 0.0, end_height, radius),
+    ]
+
+
+def _inverted_v_excitation(_params: Mapping[str, float], wires: list[WireGeometry]) -> Excitation:
+    wire1 = wires[0]
+    return Excitation(wire_tag=wire1.tag, segment=wire1.segments, voltage_real=1.0, voltage_imag=0.0)
+
+
+def _inverted_v_frequency_range(params: Mapping[str, float]) -> FrequencyRange:
+    freq = _param(params, "frequency", 7.1)
+    return _centered_frequency_range(freq, 0.1, 31)
+
+
+inverted_v_template = AntennaTemplate(
+    id="inverted-v",
+    name="Inverted V",
+    short_name="Inv V",
+    description="Dipole with drooping arms — needs only one support point.",
+    long_description=(
+        "An Inverted V is a half-wave dipole with its arms sloping downward from a single "
+        "center support. The included angle between arms affects performance: "
+        "90-120 degrees is optimal. Feed impedance is lower than a flat dipole (typically 50-60 ohms) "
+        "which can be advantageous for direct coax feed. The radiation pattern is slightly more omnidirectional "
+        "than a flat dipole, with ~1 dB less maximum gain."
+    ),
+    icon="/|\\",
+    category="wire",
+    difficulty="beginner",
+    bands=("160m", "80m", "40m", "20m", "15m", "10m"),
+    parameters=(
+        _parameter("frequency", "Design Frequency", "Center frequency for half-wave resonance", "MHz", 0.5, 2000.0, 0.1, 7.1, 3),
+        _parameter("apex_height", "Apex Height", "Height of the center feed point (top of mast)", "m", 2.0, 100.0, 0.5, 12.0, 1),
+        _parameter("included_angle", "Included Angle", "Angle between the two arms (90-180 deg, 180=flat dipole)", "deg", 60.0, 180.0, 5.0, 120.0, 0),
+        _parameter("wire_diameter", "Wire Diameter", "Conductor diameter", "mm", 0.5, 10.0, 0.1, 2.0, 1),
+    ),
+    default_ground=AVERAGE_GROUND,
+    generate_geometry=_inverted_v_geometry,
+    generate_excitation=_inverted_v_excitation,
+    default_frequency_range=_inverted_v_frequency_range,
+    tips=(
+        "90-120 degree included angle gives best compromise of gain vs. impedance.",
+        "At 90 degrees, feed impedance drops to ~50 ohms — perfect for direct coax feed.",
+        "Wire ends should be at least 2-3m above ground for safety and performance.",
+        "Broader horizontal pattern than flat dipole — less directional.",
+        "Popular for portable and field day operation (one mast + two stakes).",
+    ),
+    related_templates=("dipole", "efhw", "delta-loop"),
+)
+
+
+# ---------------------------------------------------------------------------
+# EFHW
+# ---------------------------------------------------------------------------
+
+def _efhw_geometry(params: Mapping[str, float]) -> list[WireGeometry]:
+    freq = _param(params, "frequency", 7.1)
+    feed_height = _param(params, "feed_height", 10.0)
+    far_end_height = _param(params, "far_end_height", 3.0)
+    wire_diam_mm = _param(params, "wire_diameter", 2.0)
+
+    wavelength = 300.0 / freq
+    wire_length = (wavelength / 2.0) * 0.97
+    radius = (wire_diam_mm / 1000.0) / 2.0
+
+    max_freq = freq * 1.15
+    segs = auto_segment(wire_length, max_freq, 21)
+
+    counterpoise_length = wavelength * 0.05
+    counterpoise_segs = auto_segment(counterpoise_length, max_freq, 5)
+
+    return [
+        WireGeometry(1, segs, 0.0, 0.0, feed_height, wire_length, 0.0, far_end_height, radius),
+        WireGeometry(2, counterpoise_segs, 0.0, 0.0, feed_height, -counterpoise_length, 0.0, feed_height, radius),
+    ]
+
+
+def _efhw_excitation(_params: Mapping[str, float], _wires: list[WireGeometry]) -> Excitation:
+    return Excitation(wire_tag=1, segment=1, voltage_real=1.0, voltage_imag=0.0)
+
+
+def _efhw_frequency_range(params: Mapping[str, float]) -> FrequencyRange:
+    freq = _param(params, "frequency", 7.1)
+    return _centered_frequency_range(freq, 0.1, 31)
+
+
+efhw_template = AntennaTemplate(
+    id="efhw",
+    name="End-Fed Half-Wave",
+    short_name="EFHW",
+    description="End-fed half-wave with transformer — easy single-support antenna.",
+    long_description=(
+        "An End-Fed Half-Wave (EFHW) is a half-wave wire fed at one end through a high-impedance "
+        "matching transformer (typically 49:1 unun). The antenna presents roughly 2400-5000 ohms "
+        "at the feed point, which the transformer steps down to ~50 ohms. It can be strung as a "
+        "sloper from a single support, making it ideal for portable, stealth, and field day use. "
+        "Multi-band operation is possible since harmonics (2nd, 4th) maintain high impedance at the feed."
+    ),
+    icon="—~",
+    category="wire",
+    difficulty="beginner",
+    bands=("80m", "40m", "20m", "15m", "10m"),
+    parameters=(
+        _parameter("frequency", "Design Frequency", "Fundamental frequency for half-wave resonance", "MHz", 0.5, 2000.0, 0.1, 7.1, 3),
+        _parameter("feed_height", "Feed Height", "Height of the feed point (typically at mast top)", "m", 1.0, 50.0, 0.5, 10.0, 1),
+        _parameter("far_end_height", "Far End Height", "Height of the far end of the wire", "m", 0.5, 50.0, 0.5, 3.0, 1),
+        _parameter("wire_diameter", "Wire Diameter", "Conductor diameter", "mm", 0.5, 10.0, 0.1, 2.0, 1),
+    ),
+    default_ground=AVERAGE_GROUND,
+    generate_geometry=_efhw_geometry,
+    generate_excitation=_efhw_excitation,
+    default_frequency_range=_efhw_frequency_range,
+    tips=(
+        "The 49:1 transformer is critical — without it, SWR will be extremely high.",
+        "Works well as a sloper: feed point at top of mast, far end near ground.",
+        "Resonant on even harmonics too (40m EFHW also works on 20m and 10m).",
+        "Keep the feed point coax away from the wire to minimize common-mode currents.",
+        "A short counterpoise wire (0.05λ) at the feed helps stabilize impedance.",
+    ),
+    related_templates=("dipole", "inverted-v"),
+)
+
+
+# ---------------------------------------------------------------------------
+# Vertical
+# ---------------------------------------------------------------------------
+
+def _vertical_geometry(params: Mapping[str, float]) -> list[WireGeometry]:
+    freq = _param(params, "frequency", 14.2)
+    radial_count = round(_param(params, "radial_count", 4.0))
+    radial_droop_deg = _param(params, "radial_droop", 0.0)
+    base_height = _param(params, "base_height", 0.5)
+    wire_diam_mm = _param(params, "wire_diameter", 2.0)
+
+    wavelength = 300.0 / freq
+    quarter_wave = (wavelength / 4.0) * 0.95
+    radius = (wire_diam_mm / 1000.0) / 2.0
+
+    max_freq = freq * 1.15
+    vertical_segs = auto_segment(quarter_wave, max_freq, 11)
+    radial_length = quarter_wave
+    radial_segs = auto_segment(radial_length, max_freq, 7)
+
+    wires: list[WireGeometry] = [
+        WireGeometry(1, vertical_segs, 0.0, 0.0, base_height, 0.0, 0.0, base_height + quarter_wave, radius)
+    ]
+
+    droop_rad = (radial_droop_deg * math.pi) / 180.0
+    radial_horiz_length = radial_length * math.cos(droop_rad)
+    radial_vert_drop = radial_length * math.sin(droop_rad)
+
+    for i in range(radial_count):
+        angle = (2.0 * math.pi * i) / radial_count
+        end_x = radial_horiz_length * math.cos(angle)
+        end_y = radial_horiz_length * math.sin(angle)
+        end_z = base_height - radial_vert_drop
+        wires.append(
+            WireGeometry(i + 2, radial_segs, 0.0, 0.0, base_height, end_x, end_y, end_z, radius)
+        )
+
+    return wires
+
+
+def _vertical_excitation(_params: Mapping[str, float], _wires: list[WireGeometry]) -> Excitation:
+    return Excitation(wire_tag=1, segment=1, voltage_real=1.0, voltage_imag=0.0)
+
+
+def _vertical_frequency_range(params: Mapping[str, float]) -> FrequencyRange:
+    freq = _param(params, "frequency", 14.2)
+    return _centered_frequency_range(freq, 0.15, 31)
+
+
+vertical_template = AntennaTemplate(
+    id="vertical",
+    name="Ground Plane Vertical",
+    short_name="Vertical",
+    description="Quarter-wave vertical with radials — omnidirectional, low-angle radiation.",
+    long_description=(
+        "A ground plane vertical consists of a quarter-wave vertical radiator with horizontal or "
+        "slightly drooping radial wires at its base. It produces an omnidirectional pattern in the "
+        "horizontal plane with peak radiation at low elevation angles — excellent for DX. "
+        "Feed impedance is approximately 36 ohms with horizontal radials (use a 4:1 or adjust radial droop). "
+        "With drooping radials at 45 degrees, impedance rises to ~50 ohms for direct coax feed."
+    ),
+    icon="⊥",
+    category="vertical",
+    difficulty="beginner",
+    bands=("40m", "20m", "15m", "10m", "6m", "2m"),
+    parameters=(
+        _parameter("frequency", "Design Frequency", "Center frequency for quarter-wave resonance", "MHz", 1.0, 2000.0, 0.1, 14.2, 3),
+        _parameter("radial_count", "Radials", "Number of radial wires (2-8)", "", 2.0, 8.0, 1.0, 4.0, 0),
+        _parameter("radial_droop", "Radial Droop", "Droop angle below horizontal (0=flat, 45=drooping)", "deg", 0.0, 60.0, 5.0, 0.0, 0),
+        _parameter("base_height", "Base Height", "Height of the radial junction above ground", "m", 0.3, 30.0, 0.1, 0.5, 1),
+        _parameter("wire_diameter", "Wire Diameter", "Conductor diameter", "mm", 0.5, 25.0, 0.5, 2.0, 1),
+    ),
+    default_ground=AVERAGE_GROUND,
+    generate_geometry=_vertical_geometry,
+    generate_excitation=_vertical_excitation,
+    default_frequency_range=_vertical_frequency_range,
+    tips=(
+        "4 radials is the minimum; more radials improve ground plane but with diminishing returns.",
+        "Droop radials at 45 degrees to raise impedance toward 50 ohms.",
+        "Elevated radials (not on ground) are more efficient than buried radials.",
+        "Height of the radial junction above ground affects low-angle performance.",
+        "For 20m band: vertical ~5.1m, radials ~5.1m each.",
+    ),
+    related_templates=("j-pole", "slim-jim", "efhw"),
+)
+
+
+# ---------------------------------------------------------------------------
+# Yagi
+# ---------------------------------------------------------------------------
+
+def _get_yagi_design(num_elements: int) -> dict[str, list[float]]:
+    if num_elements == 2:
+        return {"lengths": [0.252, 0.238], "positions": [0.0, 0.15]}
+    if num_elements == 3:
+        return {"lengths": [0.252, 0.238, 0.226], "positions": [0.0, 0.15, 0.35]}
+    if num_elements == 4:
+        return {"lengths": [0.252, 0.238, 0.224, 0.222], "positions": [0.0, 0.15, 0.35, 0.55]}
+    if num_elements == 5:
+        return {"lengths": [0.252, 0.238, 0.224, 0.222, 0.220], "positions": [0.0, 0.15, 0.35, 0.55, 0.75]}
+    return {"lengths": [0.252, 0.238, 0.224, 0.222, 0.220, 0.218], "positions": [0.0, 0.15, 0.35, 0.55, 0.75, 0.95]}
+
+
+def _yagi_geometry(params: Mapping[str, float]) -> list[WireGeometry]:
+    freq = _param(params, "frequency", 14.15)
+    num_elements = round(_param(params, "num_elements", 3.0))
+    height = _param(params, "height", 12.0)
+    wire_diam_mm = _param(params, "wire_diameter", 12.0)
+
+    wavelength = 300.0 / freq
+    radius = (wire_diam_mm / 1000.0) / 2.0
+    max_freq = freq * 1.15
+
+    design = _get_yagi_design(num_elements)
+    boom_offset = design["positions"][1] * wavelength
+    wires: list[WireGeometry] = []
+
+    for i in range(num_elements):
+        half_len = design["lengths"][i] * wavelength
+        boom_pos = design["positions"][i] * wavelength - boom_offset
+        segs = auto_segment(half_len * 2.0, max_freq, 11)
+        wires.append(
+            WireGeometry(i + 1, segs, -half_len, boom_pos, height, half_len, boom_pos, height, radius)
+        )
+
+    return wires
+
+
+def _yagi_excitation(_params: Mapping[str, float], wires: list[WireGeometry]) -> Excitation:
+    driven = wires[1]
+    return Excitation(
+        wire_tag=driven.tag,
+        segment=center_segment(driven.segments),
+        voltage_real=1.0,
+        voltage_imag=0.0,
+    )
+
+
+def _yagi_frequency_range(params: Mapping[str, float]) -> FrequencyRange:
+    freq = _param(params, "frequency", 14.15)
+    return _centered_frequency_range(freq, 0.07, 31)
+
+
+yagi_template = AntennaTemplate(
+    id="yagi",
+    name="Yagi-Uda",
+    short_name="Yagi",
+    description="High-gain directional beam with 2-6 elements.",
+    long_description=(
+        "The Yagi-Uda is the most popular directional antenna for amateur radio. It consists of "
+        "a driven element (fed dipole), a reflector behind it, and one or more directors in front. "
+        "Parasitic coupling between elements creates a directional pattern with high forward gain "
+        "and good front-to-back ratio. More elements = more gain and narrower beamwidth, but also "
+        "a longer boom and more critical tuning. A 3-element Yagi provides about 7-8 dBi gain."
+    ),
+    icon=">>|",
+    category="directional",
+    difficulty="intermediate",
+    bands=("20m", "15m", "10m", "6m", "2m"),
+    parameters=(
+        _parameter("frequency", "Design Frequency", "Center frequency for the Yagi design", "MHz", 1.0, 2000.0, 0.1, 14.15, 3),
+        _parameter("num_elements", "Elements", "Number of elements (2=reflector+driven, 3+=with directors)", "", 2.0, 6.0, 1.0, 3.0, 0),
+        _parameter("height", "Height", "Height above ground", "m", 2.0, 50.0, 0.5, 12.0, 1),
+        _parameter("wire_diameter", "Element Diameter", "Element tube/wire diameter", "mm", 1.0, 50.0, 1.0, 12.0, 0),
+    ),
+    default_ground=AVERAGE_GROUND,
+    generate_geometry=_yagi_geometry,
+    generate_excitation=_yagi_excitation,
+    default_frequency_range=_yagi_frequency_range,
+    tips=(
+        "The reflector is slightly longer than λ/2, directors slightly shorter.",
+        "More elements add gain but with diminishing returns above 5-6 elements.",
+        "Element spacing affects gain vs. bandwidth tradeoff.",
+        "Height above ground should be at least λ/2 for good low-angle radiation.",
+        "Boom length (not element count) is the primary determinant of gain.",
+    ),
+    related_templates=("quad", "moxon", "hex-beam"),
+)
+
+
+# ---------------------------------------------------------------------------
+# Moxon
+# ---------------------------------------------------------------------------
+
+def _moxon_dimensions(wire_diameter_wavelengths: float) -> dict[str, float]:
+    d = math.log10(wire_diameter_wavelengths)
+    a = 0.4834 - 0.0117 * d - 0.0006 * d * d
+    b = 0.0502 - 0.0192 * d - 0.0020 * d * d
+    c = 0.0365 + 0.0143 * d + 0.0014 * d * d
+    d_dim = 0.0516 + 0.0085 * d + 0.0007 * d * d
+    e = a
+    return {"A": a, "B": b, "C": c, "D": d_dim, "E": e}
+
+
+def _moxon_geometry(params: Mapping[str, float]) -> list[WireGeometry]:
+    freq = _param(params, "frequency", 14.15)
+    height = _param(params, "height", 12.0)
+    wire_diam_mm = _param(params, "wire_diameter", 2.0)
+
+    wavelength = 300.0 / freq
+    radius = wire_diam_mm / 1000.0 / 2.0
+    wire_diam_wl = (wire_diam_mm / 1000.0) / wavelength
+    max_freq = freq * 1.1
+
+    dim = _moxon_dimensions(wire_diam_wl)
+
+    half_a = dim["A"] * wavelength
+    tail_b = dim["B"] * wavelength
+    gap_c = dim["C"] * wavelength
+    tail_d = dim["D"] * wavelength
+    half_e = dim["A"] * wavelength
+
+    boom_depth = tail_b + gap_c + tail_d
+
+    segs_h = auto_segment(half_a * 2.0, max_freq, 21)
+    segs_r = auto_segment(half_e * 2.0, max_freq, 21)
+    segs_tail_b = auto_segment(tail_b, max_freq, 5)
+    segs_tail_d = auto_segment(tail_d, max_freq, 5)
+
+    y_driven = 0.0
+    y_driven_tail = -tail_b
+    y_reflector_tail = -(tail_b + gap_c)
+    y_reflector = -boom_depth
+
+    return [
+        WireGeometry(1, segs_h, -half_a, y_driven, height, half_a, y_driven, height, radius),
+        WireGeometry(2, segs_r, -half_e, y_reflector, height, half_e, y_reflector, height, radius),
+        WireGeometry(3, segs_tail_b, -half_a, y_driven, height, -half_a, y_driven_tail, height, radius),
+        WireGeometry(4, segs_tail_d, -half_e, y_reflector, height, -half_e, y_reflector_tail, height, radius),
+        WireGeometry(5, segs_tail_b, half_a, y_driven, height, half_a, y_driven_tail, height, radius),
+        WireGeometry(6, segs_tail_d, half_e, y_reflector, height, half_e, y_reflector_tail, height, radius),
+    ]
+
+
+def _moxon_excitation(_params: Mapping[str, float], wires: list[WireGeometry]) -> Excitation:
+    driven = wires[0]
+    return Excitation(
+        wire_tag=driven.tag,
+        segment=center_segment(driven.segments),
+        voltage_real=1.0,
+        voltage_imag=0.0,
+    )
+
+
+def _moxon_frequency_range(params: Mapping[str, float]) -> FrequencyRange:
+    freq = _param(params, "frequency", 14.15)
+    return _centered_frequency_range(freq, 0.08, 31)
+
+
+moxon_template = AntennaTemplate(
+    id="moxon",
+    name="Moxon Rectangle",
+    short_name="Moxon",
+    description="Compact 2-element beam with excellent front-to-back ratio.",
+    long_description=(
+        "The Moxon Rectangle is a compact directional antenna invented by Les Moxon (G6XN). "
+        "It achieves excellent front-to-back ratio (often >30 dB) with only two elements "
+        "by using closely-spaced folded-back tips that provide additional coupling. "
+        "The turning radius is about 70% of a 2-element Yagi, making it ideal for "
+        "space-constrained installations. Gain is typically 5.5-6 dBi — slightly less "
+        "than a 2-element Yagi, but with far superior F/B performance."
+    ),
+    icon="[=]",
+    category="directional",
+    difficulty="intermediate",
+    bands=("20m", "17m", "15m", "12m", "10m", "6m", "2m"),
+    parameters=(
+        _parameter("frequency", "Design Frequency", "Center frequency for the Moxon design", "MHz", 1.0, 2000.0, 0.1, 14.15, 3),
+        _parameter("height", "Height", "Height above ground", "m", 2.0, 50.0, 0.5, 12.0, 1),
+        _parameter("wire_diameter", "Wire Diameter", "Conductor diameter", "mm", 0.5, 25.0, 0.5, 2.0, 1),
+    ),
+    default_ground=AVERAGE_GROUND,
+    generate_geometry=_moxon_geometry,
+    generate_excitation=_moxon_excitation,
+    default_frequency_range=_moxon_frequency_range,
+    tips=(
+        "The gap between tail tips is critical — small changes significantly affect F/B ratio.",
+        "Turning radius is ~70% of a 2-element Yagi — great for small lots.",
+        "F/B can exceed 30 dB when properly tuned — far better than a standard Yagi.",
+        "Wire diameter affects dimensions — use the Cebik formulas for best results.",
+        "Can be built with wire for lower bands or tubing for VHF/UHF.",
+    ),
+    related_templates=("yagi", "quad", "hex-beam"),
+)
+
+
+# ---------------------------------------------------------------------------
+# J-Pole
+# ---------------------------------------------------------------------------
+
+def _j_pole_geometry(params: Mapping[str, float]) -> list[WireGeometry]:
+    freq = _param(params, "frequency", 145.0)
+    base_h = _param(params, "base_height", 1.5)
+    spacing_mm = _param(params, "spacing", 50.0)
+    wire_diam_mm = _param(params, "wire_diameter", 2.0)
+
+    wavelength = 300.0 / freq
+    radius = wire_diam_mm / 1000.0 / 2.0
+    spacing = spacing_mm / 1000.0
+    max_freq = freq * 1.1
+
+    quarter_wave = wavelength * 0.25 * 0.95
+    half_wave = wavelength * 0.5 * 0.95
+
+    long_total = quarter_wave + half_wave
+    short_total = quarter_wave
+
+    segs_long = auto_segment(long_total, max_freq, 21)
+    segs_short = auto_segment(short_total, max_freq, 11)
+    segs_bottom = auto_segment(spacing, max_freq, 3)
+
+    return [
+        WireGeometry(1, segs_long, 0.0, 0.0, base_h, 0.0, 0.0, base_h + long_total, radius),
+        WireGeometry(2, segs_short, spacing, 0.0, base_h, spacing, 0.0, base_h + short_total, radius),
+        WireGeometry(3, segs_bottom, 0.0, 0.0, base_h, spacing, 0.0, base_h, radius),
+    ]
+
+
+def _j_pole_excitation(_params: Mapping[str, float], wires: list[WireGeometry]) -> Excitation:
+    short_stub = wires[1]
+    return Excitation(wire_tag=short_stub.tag, segment=1, voltage_real=1.0, voltage_imag=0.0)
+
+
+def _j_pole_frequency_range(params: Mapping[str, float]) -> FrequencyRange:
+    freq = _param(params, "frequency", 145.0)
+    return _centered_frequency_range(freq, 0.08, 31)
+
+
+j_pole_template = AntennaTemplate(
+    id="j-pole",
+    name="J-Pole",
+    short_name="J-Pole",
+    description="End-fed half-wave vertical with quarter-wave matching stub.",
+    long_description=(
+        "The J-Pole is a half-wave vertical antenna with an integrated quarter-wave "
+        "matching section (J-matching stub). It provides omnidirectional radiation with "
+        "approximately 2-3 dBi gain and a low-angle pattern ideal for VHF/UHF. "
+        "The matching stub transforms the high impedance at the end of the half-wave "
+        "element to approximately 50 ohms. Popular for 2m and 70cm FM, and also works "
+        "well on HF bands. No radials required."
+    ),
+    icon="J|",
+    category="vertical",
+    difficulty="beginner",
+    bands=("10m", "6m", "2m", "70cm"),
+    parameters=(
+        _parameter("frequency", "Design Frequency", "Center frequency", "MHz", 1.0, 2000.0, 0.1, 145.0, 3),
+        _parameter("base_height", "Base Height", "Height of the bottom of the J above ground", "m", 0.1, 30.0, 0.1, 1.5, 1),
+        _parameter("spacing", "Element Spacing", "Gap between the two vertical sections", "mm", 10.0, 200.0, 5.0, 50.0, 0),
+        _parameter("wire_diameter", "Wire Diameter", "Conductor diameter", "mm", 0.5, 25.0, 0.5, 2.0, 1),
+    ),
+    default_ground=AVERAGE_GROUND,
+    generate_geometry=_j_pole_geometry,
+    generate_excitation=_j_pole_excitation,
+    default_frequency_range=_j_pole_frequency_range,
+    tips=(
+        "Feed point height on the short stub affects impedance — adjust for best SWR.",
+        "The spacing between the two vertical sections is typically 1-2 inches (25-50mm).",
+        "No ground radials needed — the J-match provides the current return path.",
+        "Can be made from ladder line, copper pipe, or aluminum tubing.",
+        "Excellent choice for a portable or emergency VHF/UHF antenna.",
+    ),
+    related_templates=("slim-jim", "vertical", "efhw"),
+)
+
+
+# ---------------------------------------------------------------------------
+# Slim Jim
+# ---------------------------------------------------------------------------
+
+def _slim_jim_geometry(params: Mapping[str, float]) -> list[WireGeometry]:
+    freq = _param(params, "frequency", 145.0)
+    base_h = _param(params, "base_height", 1.5)
+    spacing_mm = _param(params, "spacing", 25.0)
+    wire_diam_mm = _param(params, "wire_diameter", 2.0)
+
+    wavelength = 300.0 / freq
+    radius = wire_diam_mm / 1000.0 / 2.0
+    spacing = spacing_mm / 1000.0
+    max_freq = freq * 1.1
+
+    quarter_wave = wavelength * 0.25 * 0.95
+    half_wave = wavelength * 0.5 * 0.95
+    folded_height = half_wave
+    gap_height = wavelength * 0.01
+    total_height = quarter_wave + gap_height + folded_height
+
+    segs_long = auto_segment(total_height, max_freq, 31)
+    segs_short = auto_segment(quarter_wave, max_freq, 11)
+    segs_folded = auto_segment(folded_height, max_freq, 21)
+    segs_horiz = auto_segment(spacing, max_freq, 3)
+
+    return [
+        WireGeometry(1, segs_long, 0.0, 0.0, base_h, 0.0, 0.0, base_h + total_height, radius),
+        WireGeometry(2, segs_short, spacing, 0.0, base_h, spacing, 0.0, base_h + quarter_wave, radius),
+        WireGeometry(
+            3,
+            segs_folded,
+            spacing,
+            0.0,
+            base_h + quarter_wave + gap_height,
+            spacing,
+            0.0,
+            base_h + total_height,
+            radius,
+        ),
+        WireGeometry(4, segs_horiz, 0.0, 0.0, base_h, spacing, 0.0, base_h, radius),
+        WireGeometry(5, segs_horiz, 0.0, 0.0, base_h + total_height, spacing, 0.0, base_h + total_height, radius),
+    ]
+
+
+def _slim_jim_excitation(_params: Mapping[str, float], wires: list[WireGeometry]) -> Excitation:
+    stub = wires[1]
+    return Excitation(wire_tag=stub.tag, segment=1, voltage_real=1.0, voltage_imag=0.0)
+
+
+def _slim_jim_frequency_range(params: Mapping[str, float]) -> FrequencyRange:
+    freq = _param(params, "frequency", 145.0)
+    return _centered_frequency_range(freq, 0.08, 31)
+
+
+slim_jim_template = AntennaTemplate(
+    id="slim-jim",
+    name="Slim Jim",
+    short_name="Slim Jim",
+    description="Full-wave folded vertical with J-match — more gain than a standard J-Pole.",
+    long_description=(
+        "The Slim Jim is an end-fed folded dipole with a J-matching stub. It combines "
+        "a full-wavelength radiating section with a quarter-wave matching section, all in "
+        "a slim, vertical package. The folded design provides slightly higher gain (~3 dBi) "
+        "than a standard J-Pole due to the full-wave current distribution. The open gap at "
+        "the bottom of one side creates the necessary impedance transformation. Very popular "
+        "for portable VHF/UHF operation — can be made from 300-ohm TV twin-lead."
+    ),
+    icon="||",
+    category="vertical",
+    difficulty="beginner",
+    bands=("10m", "6m", "2m", "70cm"),
+    parameters=(
+        _parameter("frequency", "Design Frequency", "Center frequency", "MHz", 1.0, 2000.0, 0.1, 145.0, 3),
+        _parameter("base_height", "Base Height", "Height of the bottom above ground", "m", 0.1, 30.0, 0.1, 1.5, 1),
+        _parameter("spacing", "Element Spacing", "Gap between the two vertical conductors", "mm", 10.0, 200.0, 5.0, 25.0, 0),
+        _parameter("wire_diameter", "Wire Diameter", "Conductor diameter", "mm", 0.5, 25.0, 0.5, 2.0, 1),
+    ),
+    default_ground=AVERAGE_GROUND,
+    generate_geometry=_slim_jim_geometry,
+    generate_excitation=_slim_jim_excitation,
+    default_frequency_range=_slim_jim_frequency_range,
+    tips=(
+        "Can be made from 300-ohm TV twin-lead for an ultra-lightweight portable antenna.",
+        "Slightly more gain than a J-Pole due to full-wave current distribution.",
+        "The gap in one side is critical — it creates the matching impedance step.",
+        "Feed point tap position on the short side adjusts impedance (aim for 50 ohms).",
+        "Roll up and carry in your pocket for field/emergency use (twin-lead version).",
+    ),
+    related_templates=("j-pole", "vertical", "efhw"),
+)
+
+
+# ---------------------------------------------------------------------------
+# Delta Loop
+# ---------------------------------------------------------------------------
+
+def _delta_loop_geometry(params: Mapping[str, float]) -> list[WireGeometry]:
+    freq = _param(params, "frequency", 14.15)
+    base_h = _param(params, "base_height", 5.0)
+    wire_diam_mm = _param(params, "wire_diameter", 2.0)
+
+    wavelength = 300.0 / freq
+    radius = wire_diam_mm / 1000.0 / 2.0
+    max_freq = freq * 1.1
+
+    perimeter = wavelength * 1.02
+    side = perimeter / 3.0
+    half_base = side / 2.0
+    tri_height = side * math.sqrt(3.0) / 2.0
+    apex_z = base_h + tri_height
+
+    segs_base = auto_segment(side, max_freq, 21)
+    segs_side = auto_segment(side, max_freq, 21)
+
+    return [
+        WireGeometry(1, segs_base, -half_base, 0.0, base_h, half_base, 0.0, base_h, radius),
+        WireGeometry(2, segs_side, half_base, 0.0, base_h, 0.0, 0.0, apex_z, radius),
+        WireGeometry(3, segs_side, 0.0, 0.0, apex_z, -half_base, 0.0, base_h, radius),
+    ]
+
+
+def _delta_loop_excitation(_params: Mapping[str, float], wires: list[WireGeometry]) -> Excitation:
+    base = wires[0]
+    return Excitation(
+        wire_tag=base.tag,
+        segment=center_segment(base.segments),
+        voltage_real=1.0,
+        voltage_imag=0.0,
+    )
+
+
+def _delta_loop_frequency_range(params: Mapping[str, float]) -> FrequencyRange:
+    freq = _param(params, "frequency", 14.15)
+    return _centered_frequency_range(freq, 0.1, 31)
+
+
+delta_loop_template = AntennaTemplate(
+    id="delta-loop",
+    name="Delta Loop",
+    short_name="Delta",
+    description="Full-wavelength triangular loop — ~1 dB more gain than a dipole.",
+    long_description=(
+        "The Delta Loop is a full-wavelength (1λ) wire loop in a triangular shape. "
+        "It provides approximately 1 dB more gain than a half-wave dipole at the same height, "
+        "with slightly lower noise pickup. When mounted with the apex up and fed at the bottom "
+        "center, the polarization is horizontal. The feed impedance is approximately 100-120 ohms, "
+        "which can be matched with a 4:1 balun or a quarter-wave 75-ohm coax transformer. "
+        "Delta loops are popular on 40m and 80m where their triangular shape fits between "
+        "trees or on a single tall support."
+    ),
+    icon="/\\",
+    category="loop",
+    difficulty="intermediate",
+    bands=("80m", "40m", "20m", "15m", "10m"),
+    parameters=(
+        _parameter("frequency", "Design Frequency", "Resonant frequency of the loop", "MHz", 0.5, 2000.0, 0.1, 14.15, 3),
+        _parameter("base_height", "Base Height", "Height of the bottom wire above ground", "m", 0.5, 50.0, 0.5, 5.0, 1),
+        _parameter("wire_diameter", "Wire Diameter", "Conductor diameter", "mm", 0.5, 10.0, 0.1, 2.0, 1),
+    ),
+    default_ground=AVERAGE_GROUND,
+    generate_geometry=_delta_loop_geometry,
+    generate_excitation=_delta_loop_excitation,
+    default_frequency_range=_delta_loop_frequency_range,
+    tips=(
+        "Feed impedance is ~100-120 ohms — use a 4:1 balun or 75-ohm quarter-wave match.",
+        "Apex-up with bottom feed gives horizontal polarization (good for DX).",
+        "Base-down with top feed gives vertical polarization (good for local comms).",
+        "Perimeter = 1 wavelength; each side = λ/3 for equilateral triangle.",
+        "About 1 dB more gain and lower noise than a dipole at the same height.",
+    ),
+    related_templates=("horizontal-delta-loop", "quad", "dipole", "magnetic-loop"),
+)
+
+
+# ---------------------------------------------------------------------------
+# Horizontal Delta Loop
+# ---------------------------------------------------------------------------
+
+def _horizontal_delta_loop_geometry(params: Mapping[str, float]) -> list[WireGeometry]:
+    freq = _param(params, "frequency", 7.15)
+    height = _param(params, "height", 10.0)
+    wire_diam_mm = _param(params, "wire_diameter", 2.0)
+
+    wavelength = 300.0 / freq
+    radius = wire_diam_mm / 1000.0 / 2.0
+    max_freq = freq * 1.1
+
+    perimeter = wavelength * 1.02
+    side = perimeter / 3.0
+    tri_height = side * math.sqrt(3.0) / 2.0
+
+    apex_x = 0.0
+    apex_y = (2.0 * tri_height) / 3.0
+    left_x = -side / 2.0
+    left_y = -tri_height / 3.0
+    right_x = side / 2.0
+    right_y = -tri_height / 3.0
+
+    segs = auto_segment(side, max_freq, 21)
+
+    return [
+        WireGeometry(1, segs, left_x, left_y, height, right_x, right_y, height, radius),
+        WireGeometry(2, segs, right_x, right_y, height, apex_x, apex_y, height, radius),
+        WireGeometry(3, segs, apex_x, apex_y, height, left_x, left_y, height, radius),
+    ]
+
+
+def _horizontal_delta_loop_excitation(
+    _params: Mapping[str, float],
+    wires: list[WireGeometry],
+) -> Excitation:
+    base = wires[0]
+    return Excitation(
+        wire_tag=base.tag,
+        segment=center_segment(base.segments),
+        voltage_real=1.0,
+        voltage_imag=0.0,
+    )
+
+
+def _horizontal_delta_loop_frequency_range(params: Mapping[str, float]) -> FrequencyRange:
+    freq = _param(params, "frequency", 7.15)
+    return _centered_frequency_range(freq, 0.1, 31)
+
+
+horizontal_delta_loop_template = AntennaTemplate(
+    id="horizontal-delta-loop",
+    name="Horizontal Delta Loop",
+    short_name="H-Delta",
+    description="Full-wavelength horizontal triangular loop (skyloop) for multi-band HF operation.",
+    long_description=(
+        "A Horizontal Delta Loop (often called a skyloop) is a full-wavelength triangular "
+        "wire loop mounted parallel to the ground. It offers broad HF coverage with low noise "
+        "pickup and can be effective for both regional and DX operation depending on height "
+        "above ground. At lower heights it favors higher takeoff angles (NVIS/regional), and "
+        "at greater heights it supports lower-angle radiation. As with other full-wave loops, "
+        "feed impedance varies with installation details and may require matching."
+    ),
+    icon="/_\\",
+    category="loop",
+    difficulty="intermediate",
+    bands=("160m", "80m", "40m", "20m", "15m", "10m"),
+    parameters=(
+        _parameter("frequency", "Design Frequency", "Resonant frequency of the loop", "MHz", 0.5, 2000.0, 0.1, 7.15, 3),
+        _parameter("height", "Loop Height", "Height of the horizontal loop above ground", "m", 0.5, 50.0, 0.5, 10.0, 1),
+        _parameter("wire_diameter", "Wire Diameter", "Conductor diameter", "mm", 0.5, 10.0, 0.1, 2.0, 1),
+    ),
+    default_ground=AVERAGE_GROUND,
+    generate_geometry=_horizontal_delta_loop_geometry,
+    generate_excitation=_horizontal_delta_loop_excitation,
+    default_frequency_range=_horizontal_delta_loop_frequency_range,
+    tips=(
+        "Keep loop height as uniform as possible for predictable pattern behavior.",
+        "At lower heights, expect stronger high-angle radiation (regional/NVIS).",
+        "Higher installation heights improve lower-angle radiation for longer paths.",
+        "Use a tuner or matching network as feed impedance can vary with installation.",
+        "Perimeter is set near one wavelength at the design frequency.",
+    ),
+    related_templates=("delta-loop", "quad", "magnetic-loop"),
+)
+
+
+# ---------------------------------------------------------------------------
+# Quad
+# ---------------------------------------------------------------------------
+
+def _get_quad_design(num_elements: int) -> dict[str, list[float]]:
+    if num_elements == 1:
+        return {"perimeters": [1.02], "positions": [0.0]}
+    if num_elements == 2:
+        return {"perimeters": [1.05, 1.02], "positions": [0.0, 0.2]}
+    return {"perimeters": [1.05, 1.02, 0.97], "positions": [0.0, 0.2, 0.4]}
+
+
+def _quad_geometry(params: Mapping[str, float]) -> list[WireGeometry]:
+    freq = _param(params, "frequency", 14.15)
+    num_elements = round(_param(params, "num_elements", 2.0))
+    center_height = _param(params, "height", 12.0)
+    wire_diam_mm = _param(params, "wire_diameter", 2.0)
+
+    wavelength = 300.0 / freq
+    radius = (wire_diam_mm / 1000.0) / 2.0
+    max_freq = freq * 1.15
+
+    design = _get_quad_design(num_elements)
+    wires: list[WireGeometry] = []
+    tag_counter = 1
+
+    driven_idx = 0 if num_elements == 1 else 1
+    boom_offset = design["positions"][driven_idx] * wavelength
+
+    for i in range(num_elements):
+        perimeter = design["perimeters"][i] * wavelength
+        side = perimeter / 4.0
+        half_side = side / 2.0
+        boom_pos = design["positions"][i] * wavelength - boom_offset
+        side_segs = auto_segment(side, max_freq, 7)
+
+        z_bot = center_height - half_side
+        z_top = center_height + half_side
+
+        wires.append(WireGeometry(tag_counter, side_segs, -half_side, boom_pos, z_bot, half_side, boom_pos, z_bot, radius))
+        tag_counter += 1
+        wires.append(WireGeometry(tag_counter, side_segs, half_side, boom_pos, z_bot, half_side, boom_pos, z_top, radius))
+        tag_counter += 1
+        wires.append(WireGeometry(tag_counter, side_segs, half_side, boom_pos, z_top, -half_side, boom_pos, z_top, radius))
+        tag_counter += 1
+        wires.append(WireGeometry(tag_counter, side_segs, -half_side, boom_pos, z_top, -half_side, boom_pos, z_bot, radius))
+        tag_counter += 1
+
+    return wires
+
+
+def _quad_excitation(params: Mapping[str, float], wires: list[WireGeometry]) -> Excitation:
+    num_elements = round(_param(params, "num_elements", 2.0))
+    driven_bottom_tag = 1 if num_elements == 1 else 5
+    wire = next((candidate for candidate in wires if candidate.tag == driven_bottom_tag), None)
+    segs = wire.segments if wire is not None else 7
+    return Excitation(
+        wire_tag=driven_bottom_tag,
+        segment=center_segment(segs),
+        voltage_real=1.0,
+        voltage_imag=0.0,
+    )
+
+
+def _quad_frequency_range(params: Mapping[str, float]) -> FrequencyRange:
+    freq = _param(params, "frequency", 14.15)
+    return _centered_frequency_range(freq, 0.08, 31)
+
+
+quad_template = AntennaTemplate(
+    id="quad",
+    name="Cubical Quad",
+    short_name="Quad",
+    description="Full-wave loop beam — higher gain per element than a Yagi.",
+    long_description=(
+        "The Cubical Quad uses full-wave square loop elements instead of linear dipoles. "
+        "Each loop has a perimeter of approximately one wavelength. The quad provides about "
+        "1-2 dB more gain than a Yagi with the same number of elements and has lower radiation "
+        "angle. A 2-element quad (reflector + driven) gives about 7 dBi gain. The feed impedance "
+        "is approximately 100-125 ohms, requiring a matching section or 75-ohm feed with a 1.5:1 SWR."
+    ),
+    icon="[]",
+    category="directional",
+    difficulty="intermediate",
+    bands=("20m", "15m", "10m", "6m"),
+    parameters=(
+        _parameter("frequency", "Design Frequency", "Center frequency for the quad design", "MHz", 1.0, 2000.0, 0.1, 14.15, 3),
+        _parameter("num_elements", "Elements", "Number of loop elements (1-3)", "", 1.0, 3.0, 1.0, 2.0, 0),
+        _parameter("height", "Center Height", "Height of the loop centers above ground", "m", 3.0, 50.0, 0.5, 12.0, 1),
+        _parameter("wire_diameter", "Wire Diameter", "Conductor diameter", "mm", 0.5, 10.0, 0.1, 2.0, 1),
+    ),
+    default_ground=AVERAGE_GROUND,
+    generate_geometry=_quad_geometry,
+    generate_excitation=_quad_excitation,
+    default_frequency_range=_quad_frequency_range,
+    tips=(
+        "Feed at the bottom center of the driven loop for horizontal polarization.",
+        "Feed at the side center for vertical polarization.",
+        "Quad loops are less affected by nearby metallic objects than Yagi elements.",
+        "A 2-element quad roughly equals a 3-element Yagi in gain.",
+        "The bamboo/fiberglass spreader arms make this lighter than it looks.",
+    ),
+    related_templates=("yagi", "delta-loop", "hex-beam"),
+)
+
+
+# ---------------------------------------------------------------------------
+# Hex Beam
+# ---------------------------------------------------------------------------
+
+def _hex_beam_geometry(params: Mapping[str, float]) -> list[WireGeometry]:
+    freq = _param(params, "frequency", 14.15)
+    height = _param(params, "height", 12.0)
+    wire_diam_mm = _param(params, "wire_diameter", 2.0)
+
+    wavelength = 300.0 / freq
+    radius = wire_diam_mm / 1000.0 / 2.0
+    max_freq = freq * 1.1
+
+    half_width = wavelength * 0.23
+    driven_depth = wavelength * 0.07
+    reflector_depth = wavelength * 0.07
+    spacing = wavelength * 0.08
+
+    d_left_tip_x = -half_width
+    d_left_tip_y = 0.0
+    d_left_bend_x = -half_width * 0.4
+    d_left_bend_y = -driven_depth
+    d_center_x = 0.0
+    d_center_y = 0.0
+    d_right_bend_x = half_width * 0.4
+    d_right_bend_y = -driven_depth
+    d_right_tip_x = half_width
+    d_right_tip_y = 0.0
+
+    r_y = -spacing
+    r_left_tip_x = -half_width * 1.05
+    r_left_tip_y = r_y
+    r_left_bend_x = -half_width * 0.4
+    r_left_bend_y = r_y - reflector_depth
+    r_center_x = 0.0
+    r_center_y = r_y
+    r_right_bend_x = half_width * 0.4
+    r_right_bend_y = r_y - reflector_depth
+    r_right_tip_x = half_width * 1.05
+    r_right_tip_y = r_y
+
+    segs_arm = auto_segment(half_width * 0.6, max_freq, 11)
+    segs_mid = auto_segment(half_width * 0.4, max_freq, 7)
+
+    return [
+        WireGeometry(1, segs_arm, d_left_tip_x, d_left_tip_y, height, d_left_bend_x, d_left_bend_y, height, radius),
+        WireGeometry(2, segs_mid, d_left_bend_x, d_left_bend_y, height, d_center_x, d_center_y, height, radius),
+        WireGeometry(3, segs_mid, d_center_x, d_center_y, height, d_right_bend_x, d_right_bend_y, height, radius),
+        WireGeometry(4, segs_arm, d_right_bend_x, d_right_bend_y, height, d_right_tip_x, d_right_tip_y, height, radius),
+        WireGeometry(5, segs_arm, r_left_tip_x, r_left_tip_y, height, r_left_bend_x, r_left_bend_y, height, radius),
+        WireGeometry(6, segs_mid, r_left_bend_x, r_left_bend_y, height, r_center_x, r_center_y, height, radius),
+        WireGeometry(7, segs_mid, r_center_x, r_center_y, height, r_right_bend_x, r_right_bend_y, height, radius),
+        WireGeometry(8, segs_arm, r_right_bend_x, r_right_bend_y, height, r_right_tip_x, r_right_tip_y, height, radius),
+    ]
+
+
+def _hex_beam_excitation(_params: Mapping[str, float], wires: list[WireGeometry]) -> Excitation:
+    wire2 = wires[1]
+    return Excitation(wire_tag=wire2.tag, segment=wire2.segments, voltage_real=1.0, voltage_imag=0.0)
+
+
+def _hex_beam_frequency_range(params: Mapping[str, float]) -> FrequencyRange:
+    freq = _param(params, "frequency", 14.15)
+    return _centered_frequency_range(freq, 0.1, 31)
+
+
+hex_beam_template = AntennaTemplate(
+    id="hex-beam",
+    name="Hex Beam",
+    short_name="Hex",
+    description="Compact broadband beam on a hex frame — Yagi performance, smaller footprint.",
+    long_description=(
+        "The Hex Beam (or Hexagonal Beam) is a lightweight directional antenna that uses "
+        "wire elements bent into a W shape on a hexagonal frame. It provides performance "
+        "similar to a 2-element Yagi (5-6 dBi gain, 15-20 dB F/B) but with a significantly "
+        "smaller turning radius — about 60% of a full-size Yagi. The W-shaped elements "
+        "create broadband performance through capacitive end-loading. Hex beams are very "
+        "popular for multi-band HF operations, often covering 20m through 6m on a single "
+        "frame. Wind loading is very low due to the wire construction."
+    ),
+    icon="W",
+    category="directional",
+    difficulty="intermediate",
+    bands=("20m", "17m", "15m", "12m", "10m", "6m"),
+    parameters=(
+        _parameter("frequency", "Design Frequency", "Center frequency for the hex beam design", "MHz", 5.0, 2000.0, 0.1, 14.15, 3),
+        _parameter("height", "Height", "Height above ground", "m", 3.0, 50.0, 0.5, 12.0, 1),
+        _parameter("wire_diameter", "Wire Diameter", "Conductor diameter", "mm", 0.5, 10.0, 0.1, 2.0, 1),
+    ),
+    default_ground=AVERAGE_GROUND,
+    generate_geometry=_hex_beam_geometry,
+    generate_excitation=_hex_beam_excitation,
+    default_frequency_range=_hex_beam_frequency_range,
+    tips=(
+        "Turning radius is ~60% of an equivalent Yagi — great for small towers.",
+        "Very low wind loading compared to aluminum Yagis.",
+        "The W shape provides natural broadbanding through end loading.",
+        "Can easily be multiband with multiple wire sets on the same frame.",
+        "Element sag affects performance — keep the frame level.",
+        "Typical gain 5-6 dBi with 15-20 dB F/B ratio.",
+    ),
+    related_templates=("moxon", "yagi", "quad"),
+)
+
+
+# ---------------------------------------------------------------------------
+# Log Periodic
+# ---------------------------------------------------------------------------
+
+def _log_periodic_geometry(params: Mapping[str, float]) -> list[WireGeometry]:
+    freq_low = _param(params, "freq_low", 14.0)
+    freq_high = _param(params, "freq_high", 30.0)
+    tau = _param(params, "tau", 0.9)
+    sigma = _param(params, "sigma", 0.06)
+    height = _param(params, "height", 12.0)
+    wire_diam_mm = _param(params, "wire_diameter", 6.0)
+
+    radius = wire_diam_mm / 1000.0 / 2.0
+
+    lambda_max = 300.0 / freq_low
+    lambda_min = 300.0 / freq_high
+
+    half_lengths: list[float] = []
+    current_half_len = (lambda_max / 2.0) * 0.95 / 2.0
+    min_half_len = (lambda_min / 2.0) * 0.95 / 2.0 * tau
+
+    while current_half_len >= min_half_len and len(half_lengths) < 20:
+        half_lengths.append(current_half_len)
+        current_half_len *= tau
+
+    if len(half_lengths) < 2:
+        half_lengths.append(current_half_len)
+
+    spacings: list[float] = []
+    for i in range(len(half_lengths) - 1):
+        d = 4.0 * sigma * half_lengths[i]
+        spacings.append(d)
+
+    positions: list[float] = [0.0]
+    for spacing in spacings:
+        positions.append(positions[-1] + spacing)
+
+    total_boom = positions[-1]
+    offset = total_boom / 2.0
+
+    wires: list[WireGeometry] = []
+    max_freq = freq_high * 1.1
+
+    for i, half_len in enumerate(half_lengths):
+        boom_pos = positions[i] - offset
+        segs = auto_segment(half_len * 2.0, max_freq, 11)
+        wires.append(
+            WireGeometry(i + 1, segs, -half_len, boom_pos, height, half_len, boom_pos, height, radius)
+        )
+
+    return wires
+
+
+def _log_periodic_excitation(_params: Mapping[str, float], wires: list[WireGeometry]) -> Excitation:
+    front_element = wires[-1]
+    return Excitation(
+        wire_tag=front_element.tag,
+        segment=center_segment(front_element.segments),
+        voltage_real=1.0,
+        voltage_imag=0.0,
+    )
+
+
+def _log_periodic_frequency_range(params: Mapping[str, float]) -> FrequencyRange:
+    freq_low = _param(params, "freq_low", 14.0)
+    freq_high = _param(params, "freq_high", 30.0)
+    return FrequencyRange(
+        start_mhz=max(0.1, freq_low * 0.9),
+        stop_mhz=min(2000.0, freq_high * 1.1),
+        steps=51,
+    )
+
+
+log_periodic_template = AntennaTemplate(
+    id="log-periodic",
+    name="Log-Periodic Dipole Array",
+    short_name="LPDA",
+    description="Broadband directional antenna covering a wide frequency range with consistent gain.",
+    long_description=(
+        "The Log-Periodic Dipole Array (LPDA) is a broadband directional antenna that maintains "
+        "relatively constant gain and impedance across a wide frequency range. It consists of "
+        "multiple dipole elements of varying length connected to a common transposed feeder. "
+        "The element lengths and spacings are related by a constant ratio (tau), and the spacing "
+        "angle (sigma) determines the bandwidth-to-gain tradeoff. Typical gain is 6-8 dBi with "
+        "moderate F/B ratio. LPDAs are used extensively for TV reception, EMC testing, and "
+        "amateur radio where broadband coverage is needed without retuning."
+    ),
+    icon=">>>",
+    category="directional",
+    difficulty="advanced",
+    bands=("20m", "17m", "15m", "12m", "10m", "6m"),
+    parameters=(
+        _parameter("freq_low", "Low Frequency", "Lower edge of the operating range", "MHz", 1.0, 1000.0, 0.1, 14.0, 3),
+        _parameter("freq_high", "High Frequency", "Upper edge of the operating range", "MHz", 2.0, 2000.0, 0.1, 30.0, 3),
+        _parameter("tau", "Tau (τ)", "Design ratio — higher = more gain, more elements", "", 0.8, 0.98, 0.005, 0.9, 3),
+        _parameter("sigma", "Sigma (σ)", "Relative spacing factor", "", 0.03, 0.12, 0.002, 0.06, 3),
+        _parameter("height", "Height", "Height above ground", "m", 3.0, 50.0, 0.5, 12.0, 1),
+        _parameter("wire_diameter", "Element Diameter", "Element tube/wire diameter", "mm", 1.0, 25.0, 0.5, 6.0, 1),
+    ),
+    default_ground=AVERAGE_GROUND,
+    generate_geometry=_log_periodic_geometry,
+    generate_excitation=_log_periodic_excitation,
+    default_frequency_range=_log_periodic_frequency_range,
+    tips=(
+        "Tau (τ) controls the bandwidth/gain tradeoff — higher τ = more gain but more elements.",
+        "Sigma (σ) controls the spacing — typical values 0.04 to 0.08.",
+        "Feed at the shortest element (front) for correct phasing.",
+        "The transposed feeder provides 180° phase shift between adjacent elements.",
+        "Add 1-2 extra elements beyond the design range for clean pattern at band edges.",
+        "Typical gain is 6-8 dBi — less than a Yagi but over much wider bandwidth.",
+    ),
+    related_templates=("yagi", "moxon", "hex-beam"),
+)
+
+
+# ---------------------------------------------------------------------------
+# Fan Dipole
+# ---------------------------------------------------------------------------
+
+BAND_FREQS: dict[str, float] = {
+    "80m": 3.6,
+    "40m": 7.1,
+    "20m": 14.15,
+    "15m": 21.2,
+    "10m": 28.5,
+}
+
+
+def _fan_dipole_geometry(params: Mapping[str, float]) -> list[WireGeometry]:
+    num_bands = round(_param(params, "num_bands", 3.0))
+    height = _param(params, "height", 10.0)
+    fan_spread = _param(params, "fan_spread", 1.0)
+    wire_diam_mm = _param(params, "wire_diameter", 2.0)
+
+    radius = wire_diam_mm / 1000.0 / 2.0
+
+    selected_bands: list[str] = []
+    if num_bands >= 5:
+        selected_bands.extend(["80m", "40m", "20m", "15m", "10m"])
+    elif num_bands == 4:
+        selected_bands.extend(["80m", "40m", "20m", "10m"])
+    elif num_bands == 3:
+        selected_bands.extend(["40m", "20m", "10m"])
+    else:
+        selected_bands.extend(["20m", "10m"])
+
+    wires: list[WireGeometry] = []
+    tag = 1
+
+    for i, band_key in enumerate(selected_bands):
+        freq = BAND_FREQS[band_key]
+        wavelength = 300.0 / freq
+        half_len = (wavelength / 2.0) * 0.95 / 2.0
+        max_freq = freq * 1.15
+        segs = auto_segment(half_len, max_freq, 11)
+
+        vert_offset = -fan_spread * (i / (len(selected_bands) - 1)) if len(selected_bands) > 1 else 0.0
+        wire_z = height + vert_offset
+
+        wires.append(WireGeometry(tag, segs, -half_len, 0.0, wire_z, 0.0, 0.0, height, radius))
+        tag += 1
+        wires.append(WireGeometry(tag, segs, 0.0, 0.0, height, half_len, 0.0, wire_z, radius))
+        tag += 1
+
+    return wires
+
+
+def _fan_dipole_excitation(_params: Mapping[str, float], wires: list[WireGeometry]) -> Excitation:
+    first_arm = wires[0]
+    return Excitation(wire_tag=first_arm.tag, segment=first_arm.segments, voltage_real=1.0, voltage_imag=0.0)
+
+
+def _fan_dipole_frequency_range(params: Mapping[str, float]) -> FrequencyRange:
+    num_bands = round(_param(params, "num_bands", 3.0))
+    if num_bands <= 3:
+        return FrequencyRange(start_mhz=13.5, stop_mhz=14.5, steps=31)
+    return FrequencyRange(start_mhz=13.5, stop_mhz=14.5, steps=31)
+
+
+fan_dipole_template = AntennaTemplate(
+    id="fan-dipole",
+    name="Fan Dipole",
+    short_name="Fan",
+    description="Multiband dipole with separate resonant elements for each band.",
+    long_description=(
+        "The Fan Dipole is a multiband antenna using multiple dipole pairs of different "
+        "lengths, all connected at a common center feed point. Each pair is cut to be resonant "
+        "on a different band, and the elements are spread apart vertically (like a fan) to "
+        "minimize interaction. This simple approach provides multiband coverage with a single "
+        "coax feed and no tuner required on the design bands. Performance on each band is "
+        "similar to a single-band dipole. Common configurations cover 3-5 HF bands."
+    ),
+    icon="=|=",
+    category="multiband",
+    difficulty="beginner",
+    bands=("80m", "40m", "20m", "15m", "10m"),
+    parameters=(
+        _parameter("num_bands", "Number of Bands", "How many band pairs (2-5)", "", 2.0, 5.0, 1.0, 3.0, 0),
+        _parameter("height", "Height", "Height of the center feed point above ground", "m", 3.0, 30.0, 0.5, 10.0, 1),
+        _parameter("fan_spread", "Fan Spread", "Vertical separation between longest and shortest elements", "m", 0.1, 3.0, 0.1, 1.0, 1),
+        _parameter("wire_diameter", "Wire Diameter", "Conductor diameter", "mm", 0.5, 5.0, 0.1, 2.0, 1),
+    ),
+    default_ground=AVERAGE_GROUND,
+    generate_geometry=_fan_dipole_geometry,
+    generate_excitation=_fan_dipole_excitation,
+    default_frequency_range=_fan_dipole_frequency_range,
+    tips=(
+        "Spread elements vertically by 0.3-0.5m to reduce interaction between bands.",
+        "Start by cutting each pair for single-band resonance, then trim in place.",
+        "The 15m element may need significant trimming due to interaction with the 20m element.",
+        "A common feed point means only one coax run is needed.",
+        "Use spreader bars (PVC, fiberglass) to maintain element spacing.",
+        "Harmonically related bands (40m/15m) may interact — check SWR on both.",
+    ),
+    related_templates=("dipole", "g5rv", "off-center-fed"),
+)
+
+
+# ---------------------------------------------------------------------------
+# G5RV
+# ---------------------------------------------------------------------------
+
+def _g5rv_geometry(params: Mapping[str, float]) -> list[WireGeometry]:
+    height = _param(params, "height", 12.0)
+    feeder_len = _param(params, "feeder_length", 10.36)
+    dipole_len = _param(params, "dipole_length", 31.1)
+    wire_diam_mm = _param(params, "wire_diameter", 2.0)
+
+    radius = wire_diam_mm / 1000.0 / 2.0
+    half_dipole = dipole_len / 2.0
+    max_freq = 30.0
+
+    segs_dipole_arm = auto_segment(half_dipole, max_freq, 21)
+    segs_feeder = auto_segment(feeder_len, max_freq, 11)
+
+    feeder_bottom = height - feeder_len
+
+    return [
+        WireGeometry(1, segs_dipole_arm, -half_dipole, 0.0, height, 0.0, 0.0, height, radius),
+        WireGeometry(2, segs_dipole_arm, 0.0, 0.0, height, half_dipole, 0.0, height, radius),
+        WireGeometry(3, segs_feeder, 0.0, 0.0, height, 0.0, 0.0, max(feeder_bottom, 0.5), radius),
+    ]
+
+
+def _g5rv_excitation(_params: Mapping[str, float], wires: list[WireGeometry]) -> Excitation:
+    feeder = wires[2]
+    return Excitation(wire_tag=feeder.tag, segment=feeder.segments, voltage_real=1.0, voltage_imag=0.0)
+
+
+def _g5rv_frequency_range(_params: Mapping[str, float]) -> FrequencyRange:
+    return FrequencyRange(start_mhz=13.5, stop_mhz=14.5, steps=41)
+
+
+g5rv_template = AntennaTemplate(
+    id="g5rv",
+    name="G5RV",
+    short_name="G5RV",
+    description="Classic multiband dipole with open-wire matching section — 80m to 10m.",
+    long_description=(
+        "The G5RV is one of the most popular multiband wire antennas in amateur radio. "
+        "Designed by Louis Varney (G5RV), it consists of a 102-foot (31.1m) center-fed dipole "
+        "with a 34-foot (10.36m) open-wire (450-ohm ladder line) matching section dropping "
+        "vertically from the center. The open-wire section transforms the impedance on "
+        "multiple bands. It works well on 20m (where it's close to resonant) and provides "
+        "acceptable performance on 80m through 10m with an antenna tuner. The G5RV is "
+        "easy to build, inexpensive, and fits in most suburban lots."
+    ),
+    icon="T",
+    category="multiband",
+    difficulty="beginner",
+    bands=("80m", "40m", "20m", "17m", "15m", "12m", "10m"),
+    parameters=(
+        _parameter("height", "Dipole Height", "Height of the horizontal dipole wire", "m", 5.0, 30.0, 0.5, 12.0, 1),
+        _parameter("feeder_length", "Feeder Length", "Length of the open-wire matching section", "m", 5.0, 20.0, 0.5, 10.36, 2),
+        _parameter("dipole_length", "Dipole Length", "Total horizontal wire length (full-size = 31.1m)", "m", 10.0, 50.0, 0.5, 31.1, 1),
+        _parameter("wire_diameter", "Wire Diameter", "Conductor diameter", "mm", 0.5, 5.0, 0.1, 2.0, 1),
+    ),
+    default_ground=AVERAGE_GROUND,
+    generate_geometry=_g5rv_geometry,
+    generate_excitation=_g5rv_excitation,
+    default_frequency_range=_g5rv_frequency_range,
+    tips=(
+        "Works best on 20m — close to resonant, ~60 ohm feedpoint impedance.",
+        "An antenna tuner is needed for most other bands.",
+        "Keep the open-wire section as vertical as possible for best performance.",
+        "Use real 450-ohm ladder line, not 300-ohm TV twin-lead (too lossy).",
+        "A 'G5RV Junior' (half-size) covers 40m through 10m in smaller spaces.",
+        "Total horizontal span is 31.1m (102 ft) — needs good supports at both ends.",
+    ),
+    related_templates=("dipole", "fan-dipole", "off-center-fed"),
+)
+
+
+# ---------------------------------------------------------------------------
+# Off-Center-Fed
+# ---------------------------------------------------------------------------
+
+def _off_center_fed_geometry(params: Mapping[str, float]) -> list[WireGeometry]:
+    freq = _param(params, "frequency", 7.1)
+    feed_offset = _param(params, "feed_offset", 0.36)
+    height = _param(params, "height", 12.0)
+    wire_diam_mm = _param(params, "wire_diameter", 2.0)
+
+    wavelength = 300.0 / freq
+    total_len = (wavelength / 2.0) * 0.95
+    radius = wire_diam_mm / 1000.0 / 2.0
+    max_freq = freq * 4.5
+
+    short_len = feed_offset * total_len
+    long_len = (1.0 - feed_offset) * total_len
+
+    segs_short = auto_segment(short_len, max_freq, 11)
+    segs_long = auto_segment(long_len, max_freq, 21)
+
+    return [
+        WireGeometry(1, segs_short, -short_len, 0.0, height, 0.0, 0.0, height, radius),
+        WireGeometry(2, segs_long, 0.0, 0.0, height, long_len, 0.0, height, radius),
+    ]
+
+
+def _off_center_fed_excitation(_params: Mapping[str, float], wires: list[WireGeometry]) -> Excitation:
+    short_arm = wires[0]
+    return Excitation(wire_tag=short_arm.tag, segment=short_arm.segments, voltage_real=1.0, voltage_imag=0.0)
+
+
+def _off_center_fed_frequency_range(params: Mapping[str, float]) -> FrequencyRange:
+    freq = _param(params, "frequency", 7.1)
+    return _centered_frequency_range(freq, 0.1, 31)
+
+
+off_center_fed_template = AntennaTemplate(
+    id="off-center-fed",
+    name="Off-Center Fed Dipole",
+    short_name="OCF",
+    description="Windom/OCF dipole — multiband operation from a single wire with off-center feed.",
+    long_description=(
+        "The Off-Center Fed (OCF) Dipole, also known as the Windom, is a half-wave dipole "
+        "fed at a point approximately 1/3 from one end. This feed point location presents "
+        "a feed impedance of approximately 200-300 ohms (matched with a 4:1 balun to 50 ohms). "
+        "The key advantage is that the off-center feed point maintains a reasonable impedance "
+        "on even harmonics, giving multiband operation on the fundamental and approximately "
+        "every even multiple (e.g., 80m fundamental → works on 40m, 20m, 10m). "
+        "Simple construction — just one wire, a 4:1 balun, and coax."
+    ),
+    icon="--|----",
+    category="multiband",
+    difficulty="beginner",
+    bands=("80m", "40m", "20m", "10m"),
+    parameters=(
+        _parameter("frequency", "Design Frequency", "Fundamental resonant frequency", "MHz", 0.5, 2000.0, 0.1, 7.1, 3),
+        _parameter("feed_offset", "Feed Offset", "Feed point position as fraction from one end (0.33 = classic Windom)", "", 0.2, 0.45, 0.01, 0.36, 2),
+        _parameter("height", "Height", "Height above ground", "m", 2.0, 30.0, 0.5, 12.0, 1),
+        _parameter("wire_diameter", "Wire Diameter", "Conductor diameter", "mm", 0.5, 5.0, 0.1, 2.0, 1),
+    ),
+    default_ground=AVERAGE_GROUND,
+    generate_geometry=_off_center_fed_geometry,
+    generate_excitation=_off_center_fed_excitation,
+    default_frequency_range=_off_center_fed_frequency_range,
+    tips=(
+        "Feed at ~36% from one end (not exactly 1/3) for best multiband impedance.",
+        "A 4:1 current balun is essential — do NOT use a voltage balun.",
+        "Works on fundamental + even harmonics: e.g., 80/40/20/10m.",
+        "May not work well on odd harmonics (e.g., 15m for an 80m OCF).",
+        "Total wire length for 80m: ~40.5m (133 ft), for 40m: ~20.25m.",
+        "Keep the wire as straight and horizontal as possible.",
+    ),
+    related_templates=("dipole", "efhw", "g5rv", "fan-dipole"),
+)
+
+
+# ---------------------------------------------------------------------------
+# Magnetic Loop
+# ---------------------------------------------------------------------------
+
+def _magnetic_loop_geometry(params: Mapping[str, float]) -> list[WireGeometry]:
+    radius = _param(params, "radius", 0.5)
+    tube_dia = _param(params, "tube_dia", 12.0)
+    height = _param(params, "height", 3.0)
+    wire_radius = (tube_dia / 1000.0) / 2.0
+
+    arc = ArcGeometry(
+        tag=1,
+        segments=36,
+        arc_radius=radius,
+        start_angle=0.0,
+        end_angle=360.0,
+        wire_radius=wire_radius,
+    )
+    return arc_to_wire_segments(arc, height)
+
+
+def _magnetic_loop_excitation(_params: Mapping[str, float], _wires: list[WireGeometry]) -> Excitation:
+    return Excitation(wire_tag=1, segment=1, voltage_real=1.0, voltage_imag=0.0)
+
+
+def _magnetic_loop_frequency_range(params: Mapping[str, float]) -> FrequencyRange:
+    freq = _param(params, "frequency", 14.1)
+    return _centered_frequency_range(freq, 0.1, 21)
+
+
+magnetic_loop_template = AntennaTemplate(
+    id="magnetic-loop",
+    name="Small Magnetic Loop",
+    short_name="Mag Loop",
+    description="Small transmitting loop with tuning capacitor, excellent for HF in limited space.",
+    long_description=(
+        "A small magnetic loop antenna (also called a small transmitting loop or STL) "
+        "is a full circle of conductor tuned to resonance by a high-voltage variable capacitor. "
+        "Despite its small size (typically 1-3 ft diameter for HF), it can be surprisingly "
+        "efficient on 40m-10m. The radiation pattern is broadside to the plane of the loop "
+        "(figure-8 in the plane of the loop). Key advantages: very compact, low-noise receiving, "
+        "sharp tuning rejects out-of-band interference. Key limitations: very narrow bandwidth "
+        "(a few kHz on 40m), high voltages at the capacitor (several kV at 100W)."
+    ),
+    icon="O",
+    category="loop",
+    difficulty="intermediate",
+    bands=("40m", "30m", "20m", "17m", "15m", "12m", "10m"),
+    parameters=(
+        _parameter("frequency", "Design Frequency", "Center frequency for the loop", "MHz", 3.5, 30.0, 0.1, 14.1, 3),
+        _parameter("radius", "Loop Radius", "Radius of the circular loop", "m", 0.2, 2.0, 0.05, 0.5, 2),
+        _parameter("tube_dia", "Tube Diameter", "Diameter of the conductor tube/wire", "mm", 3.0, 25.0, 1.0, 12.0, 0),
+        _parameter("height", "Center Height", "Height of the loop center above ground", "m", 0.5, 15.0, 0.5, 3.0, 1),
+    ),
+    default_ground=AVERAGE_GROUND,
+    generate_geometry=_magnetic_loop_geometry,
+    generate_excitation=_magnetic_loop_excitation,
+    default_frequency_range=_magnetic_loop_frequency_range,
+    tips=(
+        "The tuning capacitor must handle very high voltages (several kV at 100W). Use a vacuum variable or high-voltage air variable.",
+        "Bandwidth is extremely narrow (a few kHz on 40m). You will need to retune for every frequency change.",
+        "Use the largest diameter conductor you can find (copper tube, 12-25mm). Efficiency improves dramatically with thicker conductors.",
+        "Keep the loop at least 1/4 wavelength from any metal structures for best performance.",
+        "The radiation pattern is broadside to the loop plane — orient the loop to point at your target direction.",
+        "This simulation uses the wire-segment approximation of the frontend preview geometry.",
+    ),
+    related_templates=("delta-loop", "quad"),
+)
+
+
+# ---------------------------------------------------------------------------
+# Inverted-L
+# ---------------------------------------------------------------------------
+
+def _inverted_l_geometry(params: Mapping[str, float]) -> list[WireGeometry]:
+    freq = _param(params, "frequency", 7.1)
+    vertical_height = _param(params, "vertical_height", 6.0)
+    base_height = _param(params, "base_height", 0.5)
+    radial_count = round(_param(params, "radial_count", 4.0))
+    radial_droop_deg = _param(params, "radial_droop", 0.0)
+    wire_diam_mm = _param(params, "wire_diameter", 2.0)
+
+    wavelength = 300.0 / freq
+    quarter_wave = (wavelength / 4.0) * 0.95
+    actual_vertical = min(vertical_height, quarter_wave)
+    horizontal_length = max(0.0, quarter_wave - actual_vertical)
+    radius = (wire_diam_mm / 1000.0) / 2.0
+
+    max_freq = freq * 1.15
+    vertical_segs = auto_segment(actual_vertical, max_freq, 11)
+    radial_length = quarter_wave
+    radial_segs = auto_segment(radial_length, max_freq, 7)
+
+    top_z = base_height + actual_vertical
+    wires: list[WireGeometry] = [
+        WireGeometry(1, vertical_segs, 0.0, 0.0, base_height, 0.0, 0.0, top_z, radius)
+    ]
+
+    next_tag = 2
+    if horizontal_length > 1e-9:
+        horizontal_segs = auto_segment(horizontal_length, max_freq, 7)
+        wires.append(
+            WireGeometry(next_tag, horizontal_segs, 0.0, 0.0, top_z, horizontal_length, 0.0, top_z, radius)
+        )
+        next_tag += 1
+
+    droop_rad = (radial_droop_deg * math.pi) / 180.0
+    radial_horiz_length = radial_length * math.cos(droop_rad)
+    radial_vert_drop = radial_length * math.sin(droop_rad)
+
+    for i in range(radial_count):
+        angle = (2.0 * math.pi * i) / radial_count
+        end_x = radial_horiz_length * math.cos(angle)
+        end_y = radial_horiz_length * math.sin(angle)
+        end_z = base_height - radial_vert_drop
+        wires.append(
+            WireGeometry(next_tag + i, radial_segs, 0.0, 0.0, base_height, end_x, end_y, end_z, radius)
+        )
+
+    return wires
+
+
+def _inverted_l_excitation(_params: Mapping[str, float], _wires: list[WireGeometry]) -> Excitation:
+    return Excitation(wire_tag=1, segment=1, voltage_real=1.0, voltage_imag=0.0)
+
+
+def _inverted_l_frequency_range(params: Mapping[str, float]) -> FrequencyRange:
+    freq = _param(params, "frequency", 7.1)
+    return _centered_frequency_range(freq, 0.15, 31)
+
+
+inverted_l_template = AntennaTemplate(
+    id="inverted-l",
+    name="Inverted-L",
+    short_name="Inv-L",
+    description="Quarter-wave vertical bent over at the top — practical HF radiator when height is limited.",
+    long_description=(
+        "The Inverted-L combines a vertical quarter-wave section with a horizontal top wire so the "
+        "overall radiator remains close to a quarter wavelength even when a full straight vertical "
+        "is impractical. The vertical section helps produce useful low-angle radiation, while the "
+        "horizontal section provides top loading and makes the antenna easier to fit on lower HF bands. "
+        "Like other base-fed verticals, it benefits from a good radial or counterpoise system. "
+        "Compared with a straight quarter-wave vertical, the Inverted-L usually produces mixed "
+        "polarization and somewhat different feed impedance, but it remains a classic choice for "
+        "40m and 80m installations where support height is limited."
+    ),
+    icon="┐",
+    category="vertical",
+    difficulty="beginner",
+    bands=("160m", "80m", "40m", "30m", "20m", "17m", "15m", "12m", "10m"),
+    parameters=(
+        _parameter("frequency", "Design Frequency", "Center frequency for quarter-wave operation", "MHz", 1.0, 2000.0, 0.1, 7.1, 3),
+        _parameter("vertical_height", "Vertical Height", "Height of the vertical section above the feed point", "m", 1.0, 30.0, 0.5, 6.0, 1),
+        _parameter("base_height", "Base Height", "Height of the feed point and radial junction above ground", "m", 0.3, 10.0, 0.1, 0.5, 1),
+        _parameter("radial_count", "Radials", "Number of radial wires (2-8)", "", 2.0, 8.0, 1.0, 4.0, 0),
+        _parameter("radial_droop", "Radial Droop", "Droop angle below horizontal (0=flat, 45=drooping)", "deg", 0.0, 60.0, 5.0, 0.0, 0),
+        _parameter("wire_diameter", "Wire Diameter", "Conductor diameter", "mm", 0.5, 10.0, 0.1, 2.0, 1),
+    ),
+    default_ground=AVERAGE_GROUND,
+    generate_geometry=_inverted_l_geometry,
+    generate_excitation=_inverted_l_excitation,
+    default_frequency_range=_inverted_l_frequency_range,
+    tips=(
+        "Keep the horizontal section away from metal supports and nearby conductors if possible.",
+        "A good radial or counterpoise system is still important for efficiency and impedance stability.",
+        "If the requested vertical section exceeds the electrical quarter-wave length, the model caps it and omits the horizontal section.",
+        "Drooping radials can move the feed impedance closer to 50 ohms, similar to other elevated verticals.",
+        "Expect a mix of vertical and horizontal polarization because the radiator bends at the top.",
+    ),
+    related_templates=("vertical", "random-wire", "efhw"),
+)
+
+
+# ---------------------------------------------------------------------------
+# Random Wire
+# ---------------------------------------------------------------------------
+
+def _random_wire_geometry(params: Mapping[str, float]) -> list[WireGeometry]:
+    freq = _param(params, "frequency", 7.1)
+    wire_length = _param(params, "wire_length", 25.0)
+    feed_height = _param(params, "feed_height", 8.0)
+    far_end_height = _param(params, "far_end_height", 3.0)
+    counterpoise_length = _param(params, "counterpoise_length", 5.0)
+    wire_diam_mm = _param(params, "wire_diameter", 2.0)
+
+    height_delta = far_end_height - feed_height
+    if abs(height_delta) > wire_length:
+        raise TemplateParameterError(
+            "random-wire geometry is impossible because wire_length is shorter than the "
+            "height difference between feed_height and far_end_height."
+        )
+
+    horizontal_run = math.sqrt(max(0.0, wire_length * wire_length - height_delta * height_delta))
+    radius = (wire_diam_mm / 1000.0) / 2.0
+    max_freq = freq * 1.15
+
+    main_segs = auto_segment(wire_length, max_freq, 21)
+    counterpoise_segs = auto_segment(counterpoise_length, max_freq, 5)
+
+    return [
+        WireGeometry(1, main_segs, 0.0, 0.0, feed_height, horizontal_run, 0.0, far_end_height, radius),
+        WireGeometry(2, counterpoise_segs, 0.0, 0.0, feed_height, -counterpoise_length, 0.0, feed_height, radius),
+    ]
+
+
+def _random_wire_excitation(_params: Mapping[str, float], _wires: list[WireGeometry]) -> Excitation:
+    return Excitation(wire_tag=1, segment=1, voltage_real=1.0, voltage_imag=0.0)
+
+
+def _random_wire_frequency_range(params: Mapping[str, float]) -> FrequencyRange:
+    freq = _param(params, "frequency", 7.1)
+    return _centered_frequency_range(freq, 0.2, 31)
+
+
+random_wire_template = AntennaTemplate(
+    id="random-wire",
+    name="Random Wire",
+    short_name="Rnd Wire",
+    description="End-fed non-resonant long wire with a short counterpoise.",
+    long_description=(
+        "A random wire antenna is a non-resonant end-fed wire that is intentionally not cut to a "
+        "specific half-wave multiple. It is commonly used with an antenna tuner and a matching "
+        "transformer or unun. Because feedpoint impedance can vary widely with frequency, a "
+        "counterpoise or other RF return path at the feed point is important for predictable "
+        "operation. Random wires are popular for portable HF use because they are easy to deploy: "
+        "raise one end, slope the far end down, add a tuner and counterpoise, and operate across "
+        "multiple bands."
+    ),
+    icon="↗",
+    category="wire",
+    difficulty="beginner",
+    bands=("160m", "80m", "40m", "30m", "20m", "17m", "15m", "12m", "10m"),
+    parameters=(
+        _parameter("frequency", "Center of Interest", "Frequency of interest for segmentation and default sweep", "MHz", 0.5, 30.0, 0.1, 7.1, 3),
+        _parameter("wire_length", "Wire Length", "Total length of the radiating wire", "m", 5.0, 100.0, 0.5, 25.0, 1),
+        _parameter("feed_height", "Feed Height", "Height of the feed end above ground", "m", 1.0, 30.0, 0.5, 8.0, 1),
+        _parameter("far_end_height", "Far End Height", "Height of the far end above ground", "m", 0.5, 30.0, 0.5, 3.0, 1),
+        _parameter("counterpoise_length", "Counterpoise Length", "Length of the short feedpoint counterpoise", "m", 1.0, 20.0, 0.5, 5.0, 1),
+        _parameter("wire_diameter", "Wire Diameter", "Conductor diameter", "mm", 0.5, 10.0, 0.1, 2.0, 1),
+    ),
+    default_ground=AVERAGE_GROUND,
+    generate_geometry=_random_wire_geometry,
+    generate_excitation=_random_wire_excitation,
+    default_frequency_range=_random_wire_frequency_range,
+    tips=(
+        "Random wires usually need an external tuner and often benefit from a 9:1 or similar matching transformer.",
+        "A short counterpoise at the feed helps provide a more stable RF return path.",
+        "Keep the feedline away from the radiating wire to reduce common-mode current on the outside of the coax.",
+        "Avoid wire lengths that create extreme feedpoint impedances on the bands you use most.",
+        "The model preserves the requested total wire length, so impossible height differences are rejected.",
+    ),
+    related_templates=("efhw", "inverted-l", "g5rv"),
+)
+
+
+# ---------------------------------------------------------------------------
+# Template registry
+# ---------------------------------------------------------------------------
+
+TEMPLATES: list[AntennaTemplate] = [
+    dipole_template,
+    inverted_v_template,
+    off_center_fed_template,
+    vertical_template,
+    inverted_l_template,
+    j_pole_template,
+    slim_jim_template,
+    efhw_template,
+    random_wire_template,
+    g5rv_template,
+    fan_dipole_template,
+    delta_loop_template,
+    horizontal_delta_loop_template,
+    quad_template,
+    magnetic_loop_template,
+    yagi_template,
+    moxon_template,
+    hex_beam_template,
+    log_periodic_template,
+]
+
+TEMPLATE_MAP: dict[str, AntennaTemplate] = {template.id: template for template in TEMPLATES}
+
+
+def list_templates() -> list[AntennaTemplate]:
+    """Return all templates in display order."""
+    return list(TEMPLATES)
+
+
+def get_template(template_id: str) -> AntennaTemplate:
+    """Get a template by ID."""
+    try:
+        return TEMPLATE_MAP[template_id]
+    except KeyError as exc:
+        valid = ", ".join(template.id for template in TEMPLATES)
+        raise TemplateNotFoundError(
+            f"Unknown template: {template_id!r}. Valid template IDs: {valid}"
+        ) from exc
+
+
+def get_default_template() -> AntennaTemplate:
+    """Return the default template."""
+    return dipole_template
+
+
+def get_default_params(template_or_id: AntennaTemplate | str) -> dict[str, float]:
+    """Return default params for a template."""
+    template = get_template(template_or_id) if isinstance(template_or_id, str) else template_or_id
+    return template.get_default_params()
+
+
+def resolve_params(
+    template_or_id: AntennaTemplate | str,
+    params: Mapping[str, Any] | None = None,
+) -> dict[str, float]:
+    """Merge provided params with defaults and validate by parameter range."""
+    template = get_template(template_or_id) if isinstance(template_or_id, str) else template_or_id
+    resolved = template.get_default_params()
+    provided = dict(params or {})
+
+    unknown = sorted(key for key in provided if key not in resolved)
+    if unknown:
+        valid = ", ".join(parameter.key for parameter in template.parameters)
+        raise TemplateParameterError(
+            f"Unknown parameter(s) for template {template.id!r}: {', '.join(unknown)}. "
+            f"Valid keys: {valid}"
+        )
+
+    for parameter in template.parameters:
+        if parameter.key not in provided:
+            continue
+
+        raw_value = provided[parameter.key]
+        if raw_value is None:
+            continue
+        if isinstance(raw_value, bool):
+            raise TemplateParameterError(
+                f"Parameter {parameter.key!r} must be numeric, not boolean."
+            )
+
+        try:
+            numeric_value = float(raw_value)
+        except (TypeError, ValueError) as exc:
+            raise TemplateParameterError(
+                f"Parameter {parameter.key!r} must be numeric; got {raw_value!r}."
+            ) from exc
+
+        if not math.isfinite(numeric_value):
+            raise TemplateParameterError(
+                f"Parameter {parameter.key!r} must be finite; got {numeric_value!r}."
+            )
+
+        if numeric_value < parameter.min or numeric_value > parameter.max:
+            raise TemplateParameterError(
+                f"Parameter {parameter.key!r} out of range for template {template.id!r}: "
+                f"{numeric_value} not in [{parameter.min}, {parameter.max}]."
+            )
+
+        resolved[parameter.key] = numeric_value
+
+    return resolved
+
+
+__all__ = [
+    "AntennaTemplate",
+    "ArcGeometry",
+    "Excitation",
+    "FrequencyRange",
+    "GroundPreset",
+    "GroundTypeName",
+    "ParameterDef",
+    "TEMPLATES",
+    "TEMPLATE_MAP",
+    "TemplateCategory",
+    "TemplateDifficulty",
+    "TemplateNotFoundError",
+    "TemplateParameterError",
+    "WireGeometry",
+    "arc_to_wire_segments",
+    "auto_segment",
+    "center_segment",
+    "get_default_params",
+    "get_default_template",
+    "get_template",
+    "list_templates",
+    "resolve_params",
+]


### PR DESCRIPTION
## Summary

Adds a standalone MCP (Model Context Protocol) server that exposes AntennaSim's NEC2 simulation capabilities as tools callable by LLM clients (Claude Desktop, Cursor, etc.) over stdio transport.

## What this enables

An LLM connected via MCP can now:

- **Discover** all 19 antenna templates with parameters, bands, and tips
- **Simulate** any template antenna with custom parameters and ground conditions
- **Compare** two antennas side by side on the same frequency sweep
- **Analyze** an antenna's performance on a specific ham band (20m, 40m, etc.)
- **Design** custom wire antennas from endpoint coordinates
- **Export** raw NEC2 card decks for any template configuration

Example prompts that work end-to-end:
- "Calcula una antena en L invertida para la banda de 20m y compárala con una EFHW"
- "¿Si quiero trabajar la banda de 20m a qué altura tengo que colocar una antena EFHW?"
- "Simulate a 3-element Yagi vs a Moxon for 14.15 MHz at 12m height"

## New files

```
mcp/
├── __init__.py           # Package marker
├── .gitignore            # Build artifact exclusions
├── pyproject.toml        # Package definition (mcp>=1.0.0, pydantic)
├── README.md             # Full setup, config, and usage docs
├── server.py             # FastMCP server with 9 tools
├── simulator.py          # NEC2 simulation wrapper (imports backend)
├── templates.py          # 19 antenna templates ported from TS to Python
└── ham_bands.py          # Ham band definitions and analysis helpers
```

## 9 MCP tools

| Tool | Description |
|------|-------------|
| `list_antenna_templates` | List all 19 templates with categories and bands |
| `get_template_info` | Detailed parameters, ranges, defaults, tips for one template |
| `list_ham_bands` | ITU Region 1/2/3 band definitions with frequencies |
| `create_and_simulate_antenna` | Template-driven simulation with full results |
| `compare_antennas` | Side-by-side comparison of two antennas |
| `analyze_antenna_for_band` | Band-specific analysis (SWR, usable BW, quality) |
| `design_wire_antenna` | Custom wire antenna from compact endpoint syntax |
| `simulate_custom_antenna` | Raw JSON wire geometry simulation |
| `get_nec2_card_deck` | Export NEC2 card deck without running nec2c |

## 19 antenna templates (2 new)

All 17 existing frontend templates ported to Python with identical geometry math, plus:
- **Inverted-L** (`inverted-l`) — quarter-wave vertical bent horizontal at top, with radials
- **Random Wire** (`random-wire`) — non-resonant end-fed wire with counterpoise

## Architecture

- The MCP server runs standalone via `python server.py` (stdio transport)
- It adds `AntennaSim/backend` to `sys.path` and imports the existing models, card deck builder, nec2c runner, and output parser directly
- No Redis required — simulations run directly through nec2c subprocess
- Template math (segmentation, Yagi NBS dimensions, Moxon Cebik formulas, LPDA tau/sigma, etc.) ported exactly from the TypeScript source

## Validation

All 9 tools validated end-to-end via MCP stdio protocol client:
- Tool registration: 9/9 tools discovered
- Template listing: 19/19 templates listed
- NEC2 simulation: dipole, inverted-L, EFHW all produce valid results
- Comparison: side-by-side tables with per-frequency data
- Band analysis: quality ratings, usable bandwidth, SWR analysis
- Custom wire design: semicolon-separated wire syntax works
- Raw JSON simulation: full backward compatibility
- NEC2 export: valid card decks with GW/GN/EX/FR/EN cards

## Setup

```bash
cd AntennaSim/mcp
pip install -e .
python server.py  # launches stdio MCP server
```

Claude Desktop config:
```json
{
  "mcpServers": {
    "antsim": {
      "command": "python",
      "args": ["AntennaSim/mcp/server.py"],
      "env": { "ANTENNASIM_BACKEND_DIR": "/path/to/AntennaSim/backend" }
    }
  }
}
```


---

**Created by Maestro on behalf of Fernando Arconada**

[View Session](https://maestro.igent.ai/thread/d325fe36-fc3e-425e-8650-ec518ea9739d)