### PR TITLE
docs: fix incorrect frequency field name in API example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+
+- Incorrect `end_mhz` field name in README API example (should be `stop_mhz`)
+
 ## [1.0.1] - 2026-03-24
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -462,7 +462,7 @@ Run a NEC2 simulation.
     { "wire_tag": 1, "segment": 11, "real": 1.0, "imag": 0.0 }
   ],
   "ground": { "type": "average" },
-  "frequency": { "start_mhz": 13.5, "end_mhz": 15.0, "steps": 31 },
+  "frequency": { "start_mhz": 13.5, "stop_mhz": 15.0, "steps": 31 },
   "compute_currents": true,
   "near_field": {
     "enabled": true,


### PR DESCRIPTION
 ## Summary
                                                                                                                                                                                                                         
  - Fix incorrect `end_mhz` field name in the simulation API example (should be `stop_mhz`)                                                                                                                              
   
  Closes #50    