### PR TITLE
fix: sort multi-band frequency segments by ascending frequency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+
+- Frequency slider displaying bands in click order instead of ascending frequency order
+- Impedance chart zigzag lines when simulating non-contiguous multi-band sweeps
+
 ## [1.0.1] - 2026-03-24
 
 ### Added

--- a/backend/src/simulation/nec_input.py
+++ b/backend/src/simulation/nec_input.py
@@ -142,7 +142,8 @@ def build_card_deck(request: SimulationRequest) -> str:
         lines.append(rp_card)
 
     if request.frequency_segments:
-        for seg in request.frequency_segments:
+        sorted_segments = sorted(request.frequency_segments, key=lambda s: s.start_mhz)
+        for seg in sorted_segments:
             emit_frequency_block(seg.start_mhz, seg.stop_mhz, seg.steps)
     else:
         freq = request.frequency

--- a/frontend/src/components/results/ImpedanceChart.tsx
+++ b/frontend/src/components/results/ImpedanceChart.tsx
@@ -38,14 +38,16 @@ interface ImpedanceChartProps {
 export function ImpedanceChart({ data, matching = DEFAULT_MATCHING, heightClass = "h-56" }: ImpedanceChartProps) {
   const chartData = useMemo(
     () =>
-      data.map((d) => {
-        const m = applyMatching(d.impedance.real, d.impedance.imag, matching);
-        return {
-          freq: d.frequency_mhz,
-          r: m.real,
-          x: m.imag,
-        };
-      }),
+      data
+        .map((d) => {
+          const m = applyMatching(d.impedance.real, d.impedance.imag, matching);
+          return {
+            freq: d.frequency_mhz,
+            r: m.real,
+            x: m.imag,
+          };
+        })
+        .sort((a, b) => a.freq - b.freq),
     [data, matching]
   );
 

--- a/frontend/src/engine/parsers/nec-input.ts
+++ b/frontend/src/engine/parsers/nec-input.ts
@@ -181,7 +181,8 @@ export function buildCardDeck(request: SimulateAdvancedRequest): string {
 
   const freqSegments = request.frequencySegments;
   if (freqSegments && freqSegments.length > 0) {
-    for (const seg of freqSegments) {
+    const sortedSegments = [...freqSegments].sort((a, b) => a.start_mhz - b.start_mhz);
+    for (const seg of sortedSegments) {
       emitFrequencyBlock(seg.start_mhz, seg.stop_mhz, seg.steps);
     }
   } else {

--- a/frontend/src/pages/EditorPage.tsx
+++ b/frontend/src/pages/EditorPage.tsx
@@ -274,7 +274,11 @@ export function EditorPage() {
       if (hasBandSegment(frequencySegments, band)) {
         setFrequencySegments(removeBandSegment(frequencySegments, band));
       } else {
-        setFrequencySegments([...frequencySegments, bandToSegment(band)]);
+        setFrequencySegments(
+          [...frequencySegments, bandToSegment(band)].sort(
+            (a, b) => a.start_mhz - b.start_mhz
+          )
+        );
       }
     },
     [frequencySegments, setFrequencySegments]

--- a/frontend/src/pages/SimulatorPage.tsx
+++ b/frontend/src/pages/SimulatorPage.tsx
@@ -129,7 +129,11 @@ export function SimulatorPage() {
         const updated = removeBandSegment(frequencySegments, band);
         setFrequencySegments(updated);
       } else {
-        setFrequencySegments([...frequencySegments, bandToSegment(band)]);
+        setFrequencySegments(
+          [...frequencySegments, bandToSegment(band)].sort(
+            (a, b) => a.start_mhz - b.start_mhz
+          )
+        );
       }
     },
     [frequencySegments, setFrequencySegments]


### PR DESCRIPTION
 ## Summary

  - Sort frequency segments by ascending frequency when toggling bands in both Simulator and Wire Editor                                                                                                                 
  - Sort segments before emitting NEC2 frequency blocks in backend and WASM card deck builders
  - Sort impedance chart data points by frequency to prevent zigzag lines between non-contiguous bands                                                                                                                   
                                                                                                                                                                                                                         
  Closes #44                                                                                                                                                                                                             
  Closes #43 