### PR TITLE
feat: transformer matching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+
+- Frequency slider SWR display ignoring transformer/matching configuration
+- Multi-band analysis table ignoring transformer/matching configuration
+
+### Changed
+
+- Move matching/balun selector next to band presets in Wire Editor for discoverability
+
 ## [1.0.1] - 2026-03-24
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - Frequency slider SWR display ignoring transformer/matching configuration
 - Multi-band analysis table ignoring transformer/matching configuration
 
+### Added
+
+- Templates now set their recommended transformer automatically (EFHW → 49:1, OCFD → 4:1, delta loop → 4:1)
+
 ### Changed
 
 - Move matching/balun selector next to band presets in Wire Editor for discoverability

--- a/frontend/src/components/results/BandAnalysis.tsx
+++ b/frontend/src/components/results/BandAnalysis.tsx
@@ -9,10 +9,13 @@ import { useMemo } from "react";
 import { analyzeBandPerformance } from "../../utils/ham-bands";
 import type { BandPerformance } from "../../utils/ham-bands";
 import type { FrequencyResult } from "../../api/nec";
+import type { MatchingConfig } from "../../utils/units";
+import { DEFAULT_MATCHING } from "../../utils/units";
 
 interface BandAnalysisProps {
   data: FrequencyResult[];
   region?: "r1" | "r2" | "r3";
+  matching?: MatchingConfig;
 }
 
 const QUALITY_STYLES: Record<BandPerformance["quality"], { bg: string; text: string; label: string }> = {
@@ -23,10 +26,10 @@ const QUALITY_STYLES: Record<BandPerformance["quality"], { bg: string; text: str
   not_simulated:  { bg: "bg-surface", text: "text-text-secondary", label: "No data" },
 };
 
-export function BandAnalysis({ data, region = "r1" }: BandAnalysisProps) {
+export function BandAnalysis({ data, region = "r1", matching = DEFAULT_MATCHING }: BandAnalysisProps) {
   const bands = useMemo(
-    () => analyzeBandPerformance(data, region).filter((b) => b.band.stop_mhz <= 30),
-    [data, region]
+    () => analyzeBandPerformance(data, region, 2.0, matching).filter((b) => b.band.stop_mhz <= 30),
+    [data, region, matching]
   );
 
   // Separate simulated vs not

--- a/frontend/src/components/results/PatternFrequencySlider.tsx
+++ b/frontend/src/components/results/PatternFrequencySlider.tsx
@@ -8,7 +8,8 @@
 
 import { useCallback, useMemo } from "react";
 import { useSimulationStore } from "../../stores/simulationStore";
-import { formatSwr, swrColorClass } from "../../utils/units";
+import { useUIStore } from "../../stores/uiStore";
+import { applyMatching, formatSwr, swrColorClass } from "../../utils/units";
 
 interface PatternFrequencySliderProps {
   /** Additional CSS classes */
@@ -24,6 +25,7 @@ export function PatternFrequencySlider({
   const result = useSimulationStore((s) => s.result);
   const selectedFreqIndex = useSimulationStore((s) => s.selectedFreqIndex);
   const setSelectedFreqIndex = useSimulationStore((s) => s.setSelectedFreqIndex);
+  const matching = useUIStore((s) => s.matching);
 
   const freqData = result?.frequency_data;
   const count = freqData?.length ?? 0;
@@ -33,6 +35,12 @@ export function PatternFrequencySlider({
     const idx = Math.min(selectedFreqIndex, count - 1);
     return freqData[idx] ?? null;
   }, [freqData, count, selectedFreqIndex]);
+
+  const displaySwr = useMemo(() => {
+    if (!currentData) return 0;
+    const m = applyMatching(currentData.impedance.real, currentData.impedance.imag, matching);
+    return m.swr;
+  }, [currentData, matching]);
 
   const handleChange = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -63,9 +71,9 @@ export function PatternFrequencySlider({
               {currentData.frequency_mhz.toFixed(compact ? 2 : 3)} MHz
             </span>
             <span
-              className={`font-mono ${compact ? "text-[9px]" : "text-[10px]"} ${swrColorClass(currentData.swr_50)}`}
+              className={`font-mono ${compact ? "text-[9px]" : "text-[10px]"} ${swrColorClass(displaySwr)}`}
             >
-              SWR {formatSwr(currentData.swr_50)}
+              SWR {formatSwr(displaySwr)}
             </span>
           </div>
         )}

--- a/frontend/src/components/results/ResultsTabs.tsx
+++ b/frontend/src/components/results/ResultsTabs.tsx
@@ -344,7 +344,7 @@ export function ResultsPanel() {
                   <h4 className="text-xs font-medium text-text-secondary">
                     Multi-Band Analysis
                   </h4>
-                  <BandAnalysis data={result.frequency_data} />
+                  <BandAnalysis data={result.frequency_data} matching={matching} />
                 </div>
               )}
 

--- a/frontend/src/pages/EditorPage.tsx
+++ b/frontend/src/pages/EditorPage.tsx
@@ -618,9 +618,6 @@ export function EditorPage() {
                     {/* Ground */}
                     <GroundEditor ground={ground} onChange={setGround} />
 
-                    {/* Matching / Balun */}
-                    <BalunEditor matching={matching} onChange={setMatching} />
-
                     {/* Pattern resolution */}
                     <div>
                       <label className="text-[10px] text-text-secondary font-semibold uppercase tracking-wider block mb-1">
@@ -679,6 +676,9 @@ export function EditorPage() {
               segments={frequencySegments}
               onSegmentsChange={setFrequencySegments}
             />
+
+            {/* Matching / Balun — near band presets for discoverability */}
+            <BalunEditor matching={matching} onChange={setMatching} />
 
             {/* Antenna height */}
             {wires.length > 0 && (
@@ -807,6 +807,8 @@ export function EditorPage() {
                 onSegmentsChange={setFrequencySegments}
                 size="sm"
               />
+              {/* Matching / Balun — near band presets for discoverability */}
+              <BalunEditor matching={matching} onChange={setMatching} />
               {/* Snap size */}
               <div>
                 <label className="text-[11px] text-text-secondary font-semibold uppercase tracking-wider block mb-1">Snap Size</label>
@@ -833,7 +835,6 @@ export function EditorPage() {
                 </select>
               </div>
               <GroundEditor ground={ground} onChange={setGround} />
-              <BalunEditor matching={matching} onChange={setMatching} />
             </div>
           )}
           {mobileTab === "tools" && (

--- a/frontend/src/pages/EditorPage.tsx
+++ b/frontend/src/pages/EditorPage.tsx
@@ -252,12 +252,13 @@ export function EditorPage() {
     setDesignFrequency(freqParam);
     setFrequencyRange(freqRange);
 
-    // Set ground from template default
+    // Set ground and matching from template defaults
     setGround(selectedTemplate.defaultGround);
+    setMatching(selectedTemplate.defaultMatching ?? { type: "none", ratio: 1, feedlineZ0: 50 });
 
     // Switch to wires section after loading
     setEditorSection("wires");
-  }, [selectedTemplate, templateParams, clearAll, setWires, setDesignFrequency, setFrequencyRange, setGround]);
+  }, [selectedTemplate, templateParams, clearAll, setWires, setDesignFrequency, setFrequencyRange, setGround, setMatching]);
 
   const handleBandSelect = useCallback(
     (range: FrequencyRange, _band: HamBand) => {

--- a/frontend/src/pages/SimulatorPage.tsx
+++ b/frontend/src/pages/SimulatorPage.tsx
@@ -90,8 +90,11 @@ export function SimulatorPage() {
 
   // Handlers
   const handleTemplateSelect = useCallback(
-    (t: AntennaTemplate) => setTemplate(t),
-    [setTemplate]
+    (t: AntennaTemplate) => {
+      setTemplate(t);
+      setMatching(t.defaultMatching ?? { type: "none", ratio: 1, feedlineZ0: 50 });
+    },
+    [setTemplate, setMatching]
   );
 
   const handleToggle = useCallback(

--- a/frontend/src/templates/delta-loop.ts
+++ b/frontend/src/templates/delta-loop.ts
@@ -45,6 +45,7 @@ export const deltaLoopTemplate: AntennaTemplate = {
   difficulty: "intermediate",
   bands: ["80m", "40m", "20m", "15m", "10m"],
   defaultGround: { type: "average" },
+  defaultMatching: { type: "balun", ratio: 4, feedlineZ0: 50 },
   tips: [
     "Feed impedance is ~100-120 ohms — use a 4:1 balun or 75-ohm quarter-wave match.",
     "Apex-up with bottom feed gives horizontal polarization (good for DX).",

--- a/frontend/src/templates/efhw.ts
+++ b/frontend/src/templates/efhw.ts
@@ -32,6 +32,7 @@ export const efhwTemplate: AntennaTemplate = {
   difficulty: "beginner",
   bands: ["80m", "40m", "20m", "15m", "10m"],
   defaultGround: { type: "average" },
+  defaultMatching: { type: "unun", ratio: 49, feedlineZ0: 50 },
   tips: [
     "The 49:1 transformer is critical — without it, SWR will be extremely high.",
     "Works well as a sloper: feed point at top of mast, far end near ground.",

--- a/frontend/src/templates/off-center-fed.ts
+++ b/frontend/src/templates/off-center-fed.ts
@@ -43,6 +43,7 @@ export const offCenterFedTemplate: AntennaTemplate = {
   difficulty: "beginner",
   bands: ["80m", "40m", "20m", "10m"],
   defaultGround: { type: "average" },
+  defaultMatching: { type: "balun", ratio: 4, feedlineZ0: 50 },
   tips: [
     "Feed at ~36% from one end (not exactly 1/3) for best multiband impedance.",
     "A 4:1 current balun is essential — do NOT use a voltage balun.",

--- a/frontend/src/templates/types.ts
+++ b/frontend/src/templates/types.ts
@@ -6,6 +6,7 @@
  */
 
 import type { WireData, FeedpointData } from "../components/three/types";
+import type { MatchingConfig } from "../utils/units";
 export type { FeedpointData } from "../components/three/types";
 
 /** Ground type enum matching backend GroundConfig */
@@ -122,6 +123,8 @@ export interface AntennaTemplate {
   parameters: ParameterDef[];
   /** Default ground configuration */
   defaultGround: GroundConfig;
+  /** Default matching/transformer for this antenna type (optional) */
+  defaultMatching?: MatchingConfig;
   /** Generate NEC2 wire geometry from parameter values */
   generateGeometry: (params: Record<string, number>) => WireGeometry[];
   /** Generate excitation source(s) from parameter values and wires */

--- a/frontend/src/utils/__tests__/ham-bands.test.ts
+++ b/frontend/src/utils/__tests__/ham-bands.test.ts
@@ -225,11 +225,15 @@ describe("removeBandSegment", () => {
 // ---------------------------------------------------------------------------
 
 describe("analyzeBandPerformance", () => {
-  // Helper to create a minimal FrequencyResult
+  // Helper to create a minimal FrequencyResult.
+  // Impedance is derived from the target SWR so that applyMatching
+  // with default matching (50Ω, 1:1) reproduces the expected SWR.
   function makeResult(freq: number, swr: number, gain: number): FrequencyResult {
+    // For a pure-real impedance: R = swr * Z0 gives the desired SWR
+    const impedanceReal = swr * 50;
     return {
       frequency_mhz: freq,
-      impedance: { real: 50, imag: 0 },
+      impedance: { real: impedanceReal, imag: 0 },
       swr_50: swr,
       gain_max_dbi: gain,
       gain_max_theta: 0,

--- a/frontend/src/utils/ham-bands.ts
+++ b/frontend/src/utils/ham-bands.ts
@@ -7,6 +7,7 @@
 
 import type { FrequencyRange, FrequencySegment } from "../templates/types";
 import type { FrequencyResult } from "../api/nec";
+import { applyMatching, DEFAULT_MATCHING, type MatchingConfig } from "./units";
 
 // ---------------------------------------------------------------------------
 // Band definitions
@@ -169,6 +170,7 @@ export function analyzeBandPerformance(
   results: FrequencyResult[],
   region: "r1" | "r2" | "r3" = "r1",
   swrThreshold: number = 2.0,
+  matching: MatchingConfig = DEFAULT_MATCHING,
 ): BandPerformance[] {
   const bands = getBandsForRegion(region);
 
@@ -192,18 +194,23 @@ export function analyzeBandPerformance(
       };
     }
 
+    // Compute SWR with matching applied
+    const swrForResult = (r: FrequencyResult) =>
+      applyMatching(r.impedance.real, r.impedance.imag, matching).swr;
+
     // Min SWR
     let minSwr = Infinity;
     let minSwrFreq = 0;
     for (const r of inBand) {
-      if (r.swr_50 < minSwr) {
-        minSwr = r.swr_50;
+      const swr = swrForResult(r);
+      if (swr < minSwr) {
+        minSwr = swr;
         minSwrFreq = r.frequency_mhz;
       }
     }
 
     // Usable bandwidth (contiguous range where SWR < threshold)
-    const usable = inBand.filter((r) => r.swr_50 <= swrThreshold);
+    const usable = inBand.filter((r) => swrForResult(r) <= swrThreshold);
     let usableBwKhz: number | null = null;
     if (usable.length > 0) {
       const minFreq = Math.min(...usable.map((r) => r.frequency_mhz));


### PR DESCRIPTION
 ## Summary

  - Apply transformer/matching configuration to the frequency slider SWR display via `applyMatching()`                                                                                                                   
  - Thread matching config through `BandAnalysis` component and `analyzeBandPerformance()` utility
  - Move matching/balun selector from Wire Editor Settings tab to main panel next to band presets for discoverability                                                                                                    
  - Add `defaultMatching` field to `AntennaTemplate` — templates now set their recommended transformer automatically (EFHW → 49:1 UnUn, OCFD → 4:1 balun, delta loop → 4:1 balun)                                        
  - Update test helper to derive impedance from target SWR for accurate assertions                                                                                                                                       
                                                                                                                                                                                                                         
  Closes #42    