### PR TITLE
feat: editor wire movement improved, fixed wire length option and bend/hang simulator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - Editable wire length field in Wire Editor properties panel and wire table
 - Length lock toggle to maintain wire length during 3D endpoint drags
 - Bend Wire tool to split a straight wire at a configurable angle and position while preserving total length
+- Multi-wire move: dragging one wire in a multi-selection moves all selected wires together
+
+### Fixed
+
+- Wire dragging at elevated heights no longer jumps to distant positions
+- Whole-wire drag sensitivity now matches mouse movement regardless of camera angle
 
 ## [1.0.1] - 2026-03-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - Length lock toggle to maintain wire length during 3D endpoint drags
 - Bend Wire tool to split a straight wire at a configurable angle and position while preserving total length
 - Multi-wire move: dragging one wire in a multi-selection moves all selected wires together
+- Blender-style axis constraints: press X/Y/Z during drag to lock to that axis, Shift+X/Y/Z to exclude an axis, with colored axis indicator lines
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Added
+
+- Editable wire length field in Wire Editor properties panel and wire table
+- Length lock toggle to maintain wire length during 3D endpoint drags
+- Bend Wire tool to split a straight wire at a configurable angle and position while preserving total length
+
 ## [1.0.1] - 2026-03-24
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - Bend Wire tool to split a straight wire at a configurable angle and position while preserving total length
 - Multi-wire move: dragging one wire in a multi-selection moves all selected wires together
 - Blender-style axis constraints: press X/Y/Z during drag to lock to that axis, Shift+X/Y/Z to exclude an axis, with colored axis indicator lines
+- Hang Wire tool to simulate gravity sag (catenary) between wire endpoints with configurable segment count
 
 ### Fixed
 

--- a/frontend/src/components/editors/WirePropertiesPanel.tsx
+++ b/frontend/src/components/editors/WirePropertiesPanel.tsx
@@ -6,7 +6,7 @@
  * shows a summary.
  */
 
-import { useCallback } from "react";
+import { useCallback, useState } from "react";
 import { useEditorStore } from "../../stores/editorStore";
 import type { EditorWire } from "../../stores/editorStore";
 import { centerSegment } from "../../engine/segmentation";
@@ -34,6 +34,126 @@ function CoordField({
   );
 }
 
+function WireLengthSection({
+  wire,
+  onSetLength,
+  onToggleLock,
+  onBend,
+}: {
+  wire: EditorWire;
+  onSetLength: (len: number) => void;
+  onToggleLock: () => void;
+  onBend: (position: number, angleDeg: number, plane: "horizontal" | "vertical", numSegments: number) => void;
+}) {
+  const [showBend, setShowBend] = useState(false);
+  const [bendAngle, setBendAngle] = useState(90);
+  const [bendPlane, setBendPlane] = useState<"horizontal" | "vertical">("horizontal");
+  const [bendSegments, setBendSegments] = useState(2);
+
+  const length = Math.sqrt(
+    (wire.x2 - wire.x1) ** 2 + (wire.y2 - wire.y1) ** 2 + (wire.z2 - wire.z1) ** 2
+  );
+
+  return (
+    <div className="border-t border-border pt-2 space-y-1.5">
+      <div className="text-[11px] text-text-secondary font-medium">Length</div>
+      <div className="flex items-center gap-1">
+        <div className="flex-1">
+          <NumberInput
+            value={length}
+            onChange={(v) => { if (v > 0) onSetLength(v); }}
+            min={0.01}
+            max={1000}
+            decimals={3}
+            unit="m"
+          />
+        </div>
+        <button
+          onClick={onToggleLock}
+          className={`p-1 rounded transition-colors ${
+            wire.lengthLocked
+              ? "bg-accent/20 text-accent"
+              : "bg-surface-hover text-text-secondary hover:text-text-primary"
+          }`}
+          title={wire.lengthLocked ? "Length locked — unlock to allow free movement" : "Lock length — endpoint drags maintain wire length"}
+        >
+          <svg viewBox="0 0 16 16" className="w-3.5 h-3.5" fill="currentColor">
+            {wire.lengthLocked ? (
+              <path d="M4 7V5a4 4 0 118 0v2h1a1 1 0 011 1v5a1 1 0 01-1 1H3a1 1 0 01-1-1V8a1 1 0 011-1h1zm2 0h4V5a2 2 0 10-4 0v2zm2 3a1 1 0 100 2 1 1 0 000-2z" />
+            ) : (
+              <path d="M10 7V5a2 2 0 10-4 0v1H4V5a4 4 0 118 0v2h1a1 1 0 011 1v5a1 1 0 01-1 1H3a1 1 0 01-1-1V8a1 1 0 011-1h7zm-2 3a1 1 0 100 2 1 1 0 000-2z" />
+            )}
+          </svg>
+        </button>
+      </div>
+
+      {/* Bend wire tool */}
+      <button
+        onClick={() => setShowBend(!showBend)}
+        className="w-full py-0.5 text-[11px] rounded bg-surface-hover text-text-secondary hover:text-text-primary transition-colors"
+      >
+        {showBend ? "Cancel bend" : "Bend wire"}
+      </button>
+
+      {showBend && (
+        <div className="space-y-1.5 bg-background rounded p-2 border border-border">
+          <div className="flex items-center gap-1.5">
+            <label className="text-[10px] text-text-secondary w-12 shrink-0">Angle</label>
+            <NumberInput
+              value={bendAngle}
+              onChange={setBendAngle}
+              min={-180}
+              max={180}
+              decimals={0}
+              unit="deg"
+              size="sm"
+            />
+          </div>
+          <div className="flex items-center gap-1.5">
+            <label className="text-[10px] text-text-secondary w-12 shrink-0">Plane</label>
+            <select
+              value={bendPlane}
+              onChange={(e) => setBendPlane(e.target.value as "horizontal" | "vertical")}
+              className="flex-1 bg-background text-text-primary text-[10px] px-1.5 py-0.5 rounded border border-border outline-none"
+            >
+              <option value="horizontal">Horizontal (XY)</option>
+              <option value="vertical">Vertical (up/down)</option>
+            </select>
+          </div>
+          <div className="flex items-center gap-1.5">
+            <label className="text-[10px] text-text-secondary w-12 shrink-0">Wires</label>
+            <NumberInput
+              value={bendSegments}
+              onChange={(v) => setBendSegments(Math.max(2, Math.min(20, Math.round(v))))}
+              min={2}
+              max={20}
+              decimals={0}
+              size="sm"
+            />
+          </div>
+          <button
+            onClick={() => {
+              onBend(0.5, bendAngle, bendPlane, bendSegments);
+              setShowBend(false);
+            }}
+            className="w-full py-1 text-[11px] rounded bg-accent/20 text-accent hover:bg-accent/30 transition-colors"
+          >
+            Apply bend
+          </button>
+          {bendSegments > 10 && (
+            <p className="text-[9px] text-swr-warning leading-tight">
+              Many wire segments may slow simulation.
+            </p>
+          )}
+          <p className="text-[9px] text-text-secondary/70 leading-tight">
+            Splits wire into {bendSegments} segments. Total length is preserved.
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}
+
 export function WirePropertiesPanel() {
   const selectedTags = useEditorStore((s) => s.selectedTags);
   const wires = useEditorStore((s) => s.wires);
@@ -44,6 +164,9 @@ export function WirePropertiesPanel() {
   const splitWire = useEditorStore((s) => s.splitWire);
   const resetSegments = useEditorStore((s) => s.resetSegments);
   const deleteWires = useEditorStore((s) => s.deleteWires);
+  const setWireLength = useEditorStore((s) => s.setWireLength);
+  const toggleLengthLock = useEditorStore((s) => s.toggleLengthLock);
+  const bendWire = useEditorStore((s) => s.bendWire);
   const pickingExcitationForTag = useEditorStore((s) => s.pickingExcitationForTag);
   const setPickingExcitationForTag = useEditorStore((s) => s.setPickingExcitationForTag);
   const accurateFeedpoint = useUIStore((s) => s.accurateFeedpoint);
@@ -194,16 +317,13 @@ export function WirePropertiesPanel() {
         />
       </div>
 
-      {/* Wire length (computed) */}
-      <div className="text-[11px] font-mono text-text-secondary border-t border-border pt-2">
-        Length:{" "}
-        {Math.sqrt(
-          (wire.x2 - wire.x1) ** 2 +
-            (wire.y2 - wire.y1) ** 2 +
-            (wire.z2 - wire.z1) ** 2
-        ).toFixed(3)}{" "}
-        m
-      </div>
+      {/* Wire length — editable + lock toggle */}
+      <WireLengthSection
+        wire={wire}
+        onSetLength={(len) => setWireLength(wire.tag, len, "end")}
+        onToggleLock={() => toggleLengthLock(wire.tag)}
+        onBend={(pos, angle, plane, segs) => bendWire(wire.tag, pos, angle, plane, segs)}
+      />
 
       {/* Excitation */}
       <div className="border-t border-border pt-2 space-y-1.5">

--- a/frontend/src/components/editors/WirePropertiesPanel.tsx
+++ b/frontend/src/components/editors/WirePropertiesPanel.tsx
@@ -39,16 +39,21 @@ function WireLengthSection({
   onSetLength,
   onToggleLock,
   onBend,
+  onHang,
 }: {
   wire: EditorWire;
   onSetLength: (len: number) => void;
   onToggleLock: () => void;
   onBend: (position: number, angleDeg: number, plane: "horizontal" | "vertical", numSegments: number) => void;
+  onHang: (numSegments: number, targetLength?: number) => void;
 }) {
   const [showBend, setShowBend] = useState(false);
   const [bendAngle, setBendAngle] = useState(90);
   const [bendPlane, setBendPlane] = useState<"horizontal" | "vertical">("horizontal");
   const [bendSegments, setBendSegments] = useState(2);
+  const [showHang, setShowHang] = useState(false);
+  const [hangSegments, setHangSegments] = useState(5);
+  const [hangLength, setHangLength] = useState<number | null>(null); // null = wire length + 1m
 
   const length = Math.sqrt(
     (wire.x2 - wire.x1) ** 2 + (wire.y2 - wire.y1) ** 2 + (wire.z2 - wire.z1) ** 2
@@ -89,7 +94,7 @@ function WireLengthSection({
 
       {/* Bend wire tool */}
       <button
-        onClick={() => setShowBend(!showBend)}
+        onClick={() => { setShowBend(!showBend); if (!showBend) setShowHang(false); }}
         className="w-full py-0.5 text-[11px] rounded bg-surface-hover text-text-secondary hover:text-text-primary transition-colors"
       >
         {showBend ? "Cancel bend" : "Bend wire"}
@@ -150,6 +155,65 @@ function WireLengthSection({
           </p>
         </div>
       )}
+
+      {/* Hang wire (catenary sag) */}
+      <button
+        onClick={() => { setShowHang(!showHang); if (!showHang) setShowBend(false); }}
+        className="w-full py-0.5 text-[11px] rounded bg-surface-hover text-text-secondary hover:text-text-primary transition-colors"
+      >
+        {showHang ? "Cancel hang" : "Hang wire"}
+      </button>
+
+      {showHang && (() => {
+        const span = Math.sqrt(
+          (wire.x2 - wire.x1) ** 2 + (wire.y2 - wire.y1) ** 2 + (wire.z2 - wire.z1) ** 2
+        );
+        const effectiveLength = hangLength ?? (length + 1);
+        const slack = Math.max(0, effectiveLength - span);
+        const sag = slack > 1e-6 ? Math.sqrt(3 * span * slack / 8) : 0;
+        return (
+        <div className="space-y-1.5 bg-background rounded p-2 border border-border">
+          <div className="flex items-center gap-1.5">
+            <label className="text-[10px] text-text-secondary w-12 shrink-0">Length</label>
+            <NumberInput
+              value={effectiveLength}
+              onChange={(v) => setHangLength(Math.max(length, v))}
+              min={length}
+              max={span * 3}
+              decimals={2}
+              unit="m"
+              size="sm"
+            />
+          </div>
+          <div className="flex items-center gap-1.5">
+            <label className="text-[10px] text-text-secondary w-12 shrink-0">Wires</label>
+            <NumberInput
+              value={hangSegments}
+              onChange={(v) => setHangSegments(Math.max(2, Math.min(30, Math.round(v))))}
+              min={2}
+              max={30}
+              decimals={0}
+              size="sm"
+            />
+          </div>
+          <div className="text-[9px] font-mono text-text-secondary">
+            Span: {span.toFixed(2)} m | Sag: {sag.toFixed(2)} m
+          </div>
+          <button
+            onClick={() => {
+              onHang(hangSegments, hangLength ?? undefined);
+              setShowHang(false);
+            }}
+            className="w-full py-1 text-[11px] rounded bg-accent/20 text-accent hover:bg-accent/30 transition-colors"
+          >
+            Apply hang
+          </button>
+          <p className="text-[9px] text-text-secondary/70 leading-tight">
+            Set length longer than the span to increase droop. More wire = more sag.
+          </p>
+        </div>
+        );
+      })()}
     </div>
   );
 }
@@ -167,6 +231,7 @@ export function WirePropertiesPanel() {
   const setWireLength = useEditorStore((s) => s.setWireLength);
   const toggleLengthLock = useEditorStore((s) => s.toggleLengthLock);
   const bendWire = useEditorStore((s) => s.bendWire);
+  const hangWire = useEditorStore((s) => s.hangWire);
   const pickingExcitationForTag = useEditorStore((s) => s.pickingExcitationForTag);
   const setPickingExcitationForTag = useEditorStore((s) => s.setPickingExcitationForTag);
   const accurateFeedpoint = useUIStore((s) => s.accurateFeedpoint);
@@ -323,6 +388,7 @@ export function WirePropertiesPanel() {
         onSetLength={(len) => setWireLength(wire.tag, len, "end")}
         onToggleLock={() => toggleLengthLock(wire.tag)}
         onBend={(pos, angle, plane, segs) => bendWire(wire.tag, pos, angle, plane, segs)}
+        onHang={(segs, len) => hangWire(wire.tag, segs, len)}
       />
 
       {/* Excitation */}

--- a/frontend/src/components/editors/WireTable.tsx
+++ b/frontend/src/components/editors/WireTable.tsx
@@ -208,6 +208,7 @@ export function WireTable() {
                   {col.label}
                 </th>
               ))}
+              <th className="w-14 px-1 py-1 text-text-secondary font-medium text-right border-b border-border">Len</th>
               <th className="w-6 px-1 py-1 border-b border-border" />
             </tr>
           </thead>
@@ -272,6 +273,12 @@ export function WireTable() {
                       </td>
                     );
                   })}
+                  {/* Computed length column */}
+                  <td className="w-14 px-1 py-0.5 text-right text-text-secondary">
+                    {formatNum(Math.sqrt(
+                      (wire.x2 - wire.x1) ** 2 + (wire.y2 - wire.y1) ** 2 + (wire.z2 - wire.z1) ** 2
+                    ))}
+                  </td>
                   <td className="w-6 px-0.5 py-0.5 text-center">
                     {isSelected && (
                       <span className="text-accent text-xs">*</span>

--- a/frontend/src/components/three/EditorScene.tsx
+++ b/frontend/src/components/three/EditorScene.tsx
@@ -12,7 +12,7 @@
  */
 
 import { Canvas, useThree, ThreeEvent } from "@react-three/fiber";
-import { Suspense, useMemo, useCallback, useState, useRef, type RefObject } from "react";
+import { Suspense, useMemo, useCallback, useState, useRef, useEffect, type RefObject } from "react";
 import { ACESFilmicToneMapping, SRGBColorSpace, Vector3, Plane, LineCurve3, TubeGeometry, MeshBasicMaterial } from "three";
 import { GroundPlane } from "./GroundPlane";
 import { CompassRose } from "./CompassRose";
@@ -71,18 +71,56 @@ function GhostWire({ start, end }: { start: Vector3; end: Vector3 }) {
   );
 }
 
-/** Drag target: either an endpoint or the entire wire, optionally vertical-only.
- *  origZ tracks the NEC2 Z of the dragged point at drag start so we can preserve height. */
+/** Visual axis constraint indicator — colored line(s) through the dragged point */
+function AxisConstraintLine({ axis, position }: { axis: AxisConstraint; position: [number, number, number] }) {
+  if (!axis) return null;
+  const LEN = 50;
+  const [px, py, pz] = position;
+  // NEC2 coords → Three.js: [x, z, -y]
+  const cx = px, cy = pz, cz = -py;
+
+  const colors: Record<string, string> = { x: "#ef4444", y: "#22c55e", z: "#3b82f6" };
+  // For single axis: show that axis line. For plane (xy/xz/yz): show both axis lines.
+  const axes = axis.length === 1 ? [axis] : axis.split("");
+
+  return (
+    <group>
+      {axes.map((a) => {
+        const dir: [number, number, number] =
+          a === "x" ? [LEN, 0, 0] : a === "y" ? [0, 0, -LEN] : [0, LEN, 0];
+        const points = [
+          [cx - dir[0], cy - dir[1], cz - dir[2]] as [number, number, number],
+          [cx + dir[0], cy + dir[1], cz + dir[2]] as [number, number, number],
+        ];
+        return (
+          <line key={a}>
+            <bufferGeometry>
+              <bufferAttribute
+                attach="attributes-position"
+                args={[new Float32Array(points.flat()), 3]}
+                count={2}
+              />
+            </bufferGeometry>
+            <lineBasicMaterial color={colors[a]} opacity={0.7} transparent linewidth={1} />
+          </line>
+        );
+      })}
+    </group>
+  );
+}
+
+/** Axis constraint during drag: null=free, "x"/"y"/"z"=lock to axis, "xy"/"xz"/"yz"=exclude axis */
+type AxisConstraint = null | "x" | "y" | "z" | "xy" | "xz" | "yz";
+
 type DragTarget =
   | { type: "endpoint"; tag: number; endpoint: "start" | "end";
-      /** Last camera-plane intersection in Three.js coords for delta computation */
       lastHit?: { x: number; y: number; z: number };
-      /** NEC2 XY unit direction in the wire's horizontal plane (for Shift+lock arc) */
-      initDirX?: number; initDirY?: number;
-      /** Current angle in radians from horizontal for Shift+lock pendulum (0=horizontal, π/2=up) */
-      arcAngle?: number }
+      axisConstraint: AxisConstraint }
   | { type: "wire"; tag: number;
-      lastHit?: { x: number; y: number; z: number } };
+      lastHit?: { x: number; y: number; z: number };
+      /** Fixed camera-plane anchor so the plane doesn't drift with the wire */
+      planeAnchor?: { x: number; y: number; z: number };
+      axisConstraint: AxisConstraint };
 
 /** Inner scene content — needs access to useThree */
 function EditorSceneContent({
@@ -110,7 +148,6 @@ function EditorSceneContent({
   const moveWire = useEditorStore((s) => s.moveWire);
   const moveSelected = useEditorStore((s) => s.moveSelected);
   const toggleSelection = useEditorStore((s) => s.toggleSelection);
-  const verticalDrag = useEditorStore((s) => s.verticalDrag);
   const pickingExcitationForTag = useEditorStore((s) => s.pickingExcitationForTag);
   const setExcitation = useEditorStore((s) => s.setExcitation);
   const setPickingExcitationForTag = useEditorStore((s) => s.setPickingExcitationForTag);
@@ -138,11 +175,58 @@ function EditorSceneContent({
   // Ghost wire preview position
   const [ghostEnd, setGhostEnd] = useState<[number, number, number] | null>(null);
 
+  // Axis constraint visual indicator (shown in 3D during drag)
+  const [axisIndicator, setAxisIndicator] = useState<{ axis: AxisConstraint; pos: [number, number, number] } | null>(null);
+
   // Drag state — when non-null, orbit controls are disabled
   const [isDragging, setIsDragging] = useState(false);
   const dragRef = useRef<DragTarget | null>(null);
 
   const { raycaster, camera, controls } = useThree();
+
+  // Listen for X/Y/Z key presses during drag to set axis constraint
+  useEffect(() => {
+    if (!isDragging) {
+      setAxisIndicator(null);
+      return;
+    }
+    const handleKey = (e: KeyboardEvent) => {
+      if (!dragRef.current) return;
+      const key = e.key.toLowerCase();
+      const shift = e.shiftKey;
+      if (key === "x" || key === "y" || key === "z") {
+        e.preventDefault();
+        const current = dragRef.current.axisConstraint;
+        let next: AxisConstraint;
+        if (shift) {
+          // Shift+X = exclude X (move YZ), etc.
+          const exclude = key === "x" ? "yz" : key === "y" ? "xz" : "xy";
+          next = current === exclude ? null : exclude;
+        } else {
+          // X = lock to X, press again = free
+          next = current === key ? null : key;
+        }
+        dragRef.current.axisConstraint = next;
+        // Update indicator position from current wire/endpoint
+        const target = dragRef.current;
+        const wire = wires.find((w) => w.tag === target.tag);
+        if (wire && next) {
+          const pos: [number, number, number] = target.type === "endpoint"
+            ? (target.endpoint === "start" ? [wire.x1, wire.y1, wire.z1] : [wire.x2, wire.y2, wire.z2])
+            : [(wire.x1 + wire.x2) / 2, (wire.y1 + wire.y2) / 2, (wire.z1 + wire.z2) / 2];
+          setAxisIndicator({ axis: next, pos });
+        } else {
+          setAxisIndicator(null);
+        }
+      }
+      if (key === "escape") {
+        dragRef.current.axisConstraint = null;
+        setAxisIndicator(null);
+      }
+    };
+    window.addEventListener("keydown", handleKey);
+    return () => window.removeEventListener("keydown", handleKey);
+  }, [isDragging, wires]);
 
   /** Raycast to ground plane to get NEC2 coordinates (horizontal movement: X/Y) */
   const raycastToGround = useCallback(
@@ -225,33 +309,40 @@ function EditorSceneContent({
         const target = dragRef.current;
         if (!target.lastHit) return;
 
-        const shiftHeld = event.nativeEvent.shiftKey || verticalDrag;
-        const altHeld = event.nativeEvent.altKey;
-        const anchor = new Vector3(target.lastHit.x, target.lastHit.y, target.lastHit.z);
-
-        // Camera-facing plane for all modes — orbit controls are disabled
-        // during dragging so the plane stays stable between frames.
+        // For wires: use fixed planeAnchor so the plane doesn't drift as the wire moves.
+        // For endpoints: use lastHit (which tracks the endpoint position).
+        const anchorSrc = (target.type === "wire" && target.planeAnchor) ? target.planeAnchor : target.lastHit;
+        const anchor = new Vector3(anchorSrc.x, anchorSrc.y, anchorSrc.z);
         const hit = raycastCameraPlane(event, anchor);
         if (!hit) return;
 
         let dtx = hit.x - target.lastHit.x;
-        let dty = hit.y - target.lastHit.y;
+        let dty = hit.y - target.lastHit.y; // Three.js Y = NEC2 Z
         let dtz = hit.z - target.lastHit.z;
 
-        if (shiftHeld) {
-          dtx = 0; dtz = 0;
-          target.lastHit = { x: target.lastHit.x, y: hit.y, z: target.lastHit.z };
-        } else if (altHeld) {
-          dty = 0;
-          target.lastHit = { x: hit.x, y: target.lastHit.y, z: hit.z };
-        } else {
-          target.lastHit = { x: hit.x, y: hit.y, z: hit.z };
-        }
+        // Convert to NEC2 before applying axis constraint
+        // Three.js (dtx, dty, dtz) -> NEC2 (dtx, -dtz, dty)
+        let necDx = dtx;
+        let necDy = -dtz;
+        let necDz = dty;
 
-        // Convert delta: Three.js (dtx, dty, dtz) -> NEC2 (dtx, -dtz, dty)
-        const necDx = dtx;
-        const necDy = -dtz;
-        const necDz = dty;
+        // Apply axis constraint in NEC2 space
+        const ac = target.axisConstraint;
+        if (ac === "x") { necDy = 0; necDz = 0; }
+        else if (ac === "y") { necDx = 0; necDz = 0; }
+        else if (ac === "z") { necDx = 0; necDy = 0; }
+        else if (ac === "xy") { necDz = 0; }
+        else if (ac === "xz") { necDy = 0; }
+        else if (ac === "yz") { necDx = 0; }
+
+        // Update lastHit: freeze the Three.js axes that map to zeroed NEC2 axes
+        // to prevent drift on constrained axes
+        const newLastHit = { x: hit.x, y: hit.y, z: hit.z };
+        // NEC2 X = Three.js X, NEC2 Y = -Three.js Z, NEC2 Z = Three.js Y
+        if (necDx === 0 && dtx !== 0) newLastHit.x = target.lastHit.x;
+        if (necDy === 0 && dtz !== 0) newLastHit.z = target.lastHit.z;
+        if (necDz === 0 && dty !== 0) newLastHit.y = target.lastHit.y;
+        target.lastHit = newLastHit;
 
         if (Math.abs(necDx) < 1e-9 && Math.abs(necDy) < 1e-9 && Math.abs(necDz) < 1e-9) return;
 
@@ -264,46 +355,57 @@ function EditorSceneContent({
           let newY = (endpoint === "start" ? wire.y1 : wire.y2) + necDy;
           let newZ = (endpoint === "start" ? wire.z1 : wire.z2) + necDz;
 
-          // Length lock: maintain wire length while respecting axis constraints
+          // Length lock: clamp to sphere while respecting axis constraint
           if (wire.lengthLocked) {
             const [fx, fy, fz] = endpoint === "start"
               ? [wire.x2, wire.y2, wire.z2]
               : [wire.x1, wire.y1, wire.z1];
-            const wireLen = Math.sqrt(
+            const L = Math.sqrt(
               (wire.x2 - wire.x1) ** 2 + (wire.y2 - wire.y1) ** 2 + (wire.z2 - wire.z1) ** 2
             );
-            if (wireLen > 1e-9) {
-              if (altHeld) {
-                // Horizontal only: keep Z fixed, scale XY to maintain length
-                const dz = newZ - fz;
-                const hNeededSq = wireLen * wireLen - dz * dz;
-                if (hNeededSq > 0) {
-                  const hx = newX - fx, hy = newY - fy;
-                  const hDist = Math.sqrt(hx * hx + hy * hy);
-                  if (hDist > 1e-9) {
-                    const scale = Math.sqrt(hNeededSq) / hDist;
-                    newX = fx + hx * scale;
-                    newY = fy + hy * scale;
+            if (L > 1e-9) {
+              if (ac === "x" || ac === "y" || ac === "z") {
+                // Single axis: only 2 valid positions on that axis line
+                // Fixed axes use current endpoint values
+                const fixedSq = (ac !== "x" ? 0 : (newY - fy) ** 2 + (newZ - fz) ** 2)
+                             + (ac !== "y" ? 0 : (newX - fx) ** 2 + (newZ - fz) ** 2)
+                             + (ac !== "z" ? 0 : (newX - fx) ** 2 + (newY - fy) ** 2);
+                const rem = L * L - fixedSq;
+                if (rem >= 0) {
+                  const d = Math.sqrt(rem);
+                  // Pick the closer of the two valid positions
+                  const cur = ac === "x" ? newX - fx : ac === "y" ? newY - fy : newZ - fz;
+                  const clamped = Math.abs(cur - d) < Math.abs(cur + d) ? d : -d;
+                  if (ac === "x") newX = fx + clamped;
+                  else if (ac === "y") newY = fy + clamped;
+                  else newZ = fz + clamped;
+                } else {
+                  // Unreachable on this axis — clamp to max
+                  if (ac === "x") { newX = fx + (newX >= fx ? L : -L); newY = fy; newZ = fz; }
+                  else if (ac === "y") { newY = fy + (newY >= fy ? L : -L); newX = fx; newZ = fz; }
+                  else { newZ = fz + (newZ >= fz ? L : -L); newX = fx; newY = fy; }
+                }
+              } else if (ac === "xy" || ac === "xz" || ac === "yz") {
+                // Plane: scale the 2 free axes to maintain length with the fixed axis
+                const fixedD = ac === "xy" ? newZ - fz : ac === "xz" ? newY - fy : newX - fx;
+                const needed = L * L - fixedD * fixedD;
+                if (needed > 0) {
+                  const a1 = ac === "yz" ? newY - fy : newX - fx;
+                  const a2 = ac === "xy" ? newY - fy : newZ - fz;
+                  const dist = Math.sqrt(a1 * a1 + a2 * a2);
+                  if (dist > 1e-9) {
+                    const scale = Math.sqrt(needed) / dist;
+                    if (ac === "yz") { newY = fy + a1 * scale; newZ = fz + a2 * scale; }
+                    else if (ac === "xz") { newX = fx + a1 * scale; newZ = fz + a2 * scale; }
+                    else { newX = fx + a1 * scale; newY = fy + a2 * scale; }
                   }
                 }
-              } else if (shiftHeld) {
-                // Vertical arc: update the angle from Z delta, compute
-                // position on the circle. Full 360° rotation.
-                const prevAngle = target.arcAngle ?? 0;
-                const angleDelta = necDz / wireLen; // scale Z delta to angle
-                const angle = prevAngle + angleDelta;
-                target.arcAngle = angle;
-                const dirX = target.initDirX ?? 1;
-                const dirY = target.initDirY ?? 0;
-                newX = fx + dirX * wireLen * Math.cos(angle);
-                newY = fy + dirY * wireLen * Math.cos(angle);
-                newZ = fz + wireLen * Math.sin(angle);
               } else {
-                // Free movement: project onto sphere
+                // Free: project onto sphere
                 const dx = newX - fx, dy = newY - fy, dz = newZ - fz;
                 const dist = Math.sqrt(dx * dx + dy * dy + dz * dz);
                 if (dist > 1e-9) {
-                  const scale = wireLen / dist;
+                  const scale = L / dist;
                   newX = fx + dx * scale;
                   newY = fy + dy * scale;
                   newZ = fz + dz * scale;
@@ -318,13 +420,8 @@ function EditorSceneContent({
             updateWire(tag, { x2: newX, y2: newY, z2: newZ });
           }
 
-          // Length-lock projection moves the endpoint to a different position
-          // than the raw camera-plane hit. Re-sync lastHit to the actual
-          // endpoint so the next frame's delta starts from where it really is.
-          // Exception: Shift uses angle tracking where lastHit must stay on
-          // the camera plane for consistent sensitivity through 360°.
-          if (wire.lengthLocked && target.lastHit && !shiftHeld) {
-            // NEC2 (newX, newY, newZ) -> Three.js (newX, newZ, -newY)
+          // Re-sync lastHit to actual endpoint after length-lock projection
+          if (wire.lengthLocked && target.lastHit) {
             target.lastHit = { x: newX, y: newZ, z: -newY };
           }
         } else if (target.type === "wire") {
@@ -336,7 +433,7 @@ function EditorSceneContent({
         }
       }
     },
-    [mode, addStart, isDragging, verticalDrag, snapSize, wires, selectedTags, raycastToGround, raycastCameraPlane, updateWire, moveWire, moveSelected]
+    [mode, addStart, isDragging, wires, selectedTags, raycastToGround, raycastCameraPlane, updateWire, moveWire, moveSelected]
   );
 
   const handlePointerUp = useCallback(() => {
@@ -367,31 +464,13 @@ function EditorSceneContent({
     (tag: number, endpoint: "start" | "end", event: ThreeEvent<PointerEvent>) => {
       if (mode === "move") {
         const wire = wires.find((w) => w.tag === tag);
-        // Use actual click point on the endpoint sphere as camera-plane anchor
         const ep = event.point ?? (wire
           ? (endpoint === "start" ? new Vector3(wire.x1, wire.z1, -wire.y1) : new Vector3(wire.x2, wire.z2, -wire.y2))
           : new Vector3());
         const hit = raycastCameraPlane(event, ep);
-        // Capture initial XY direction for length-lock fallback when XY shrinks to 0
-        let initDirX = 0, initDirY = 0;
-        if (wire) {
-          const [fx, fy] = endpoint === "start" ? [wire.x2, wire.y2] : [wire.x1, wire.y1];
-          const [mx, my] = endpoint === "start" ? [wire.x1, wire.y1] : [wire.x2, wire.y2];
-          const hd = Math.sqrt((mx - fx) ** 2 + (my - fy) ** 2);
-          if (hd > 1e-9) { initDirX = (mx - fx) / hd; initDirY = (my - fy) / hd; }
-          else { initDirX = 1; initDirY = 0; }
-        }
-        // Compute initial arc angle for Shift+lock pendulum
-        let arcAngle = 0;
-        if (wire) {
-          const [fx2, fy2, fz2] = endpoint === "start" ? [wire.x2, wire.y2, wire.z2] : [wire.x1, wire.y1, wire.z1];
-          const [mx2, my2, mz2] = endpoint === "start" ? [wire.x1, wire.y1, wire.z1] : [wire.x2, wire.y2, wire.z2];
-          const hd2 = Math.sqrt((mx2 - fx2) ** 2 + (my2 - fy2) ** 2);
-          arcAngle = Math.atan2(mz2 - fz2, hd2);
-        }
         if (controls) (controls as unknown as { enabled: boolean }).enabled = false;
         setIsDragging(true);
-        dragRef.current = { type: "endpoint", tag, endpoint, initDirX, initDirY, arcAngle, lastHit: hit ? { x: hit.x, y: hit.y, z: hit.z } : undefined };
+        dragRef.current = { type: "endpoint", tag, endpoint, axisConstraint: null, lastHit: hit ? { x: hit.x, y: hit.y, z: hit.z } : undefined };
       }
     },
     [mode, wires, controls, raycastCameraPlane]
@@ -409,7 +488,8 @@ function EditorSceneContent({
         const hit = raycastCameraPlane(event, clickPoint);
         if (controls) (controls as unknown as { enabled: boolean }).enabled = false;
         setIsDragging(true);
-        dragRef.current = { type: "wire", tag, lastHit: hit ? { x: hit.x, y: hit.y, z: hit.z } : undefined };
+        const hitObj = hit ? { x: hit.x, y: hit.y, z: hit.z } : undefined;
+        dragRef.current = { type: "wire", tag, axisConstraint: null, lastHit: hitObj, planeAnchor: hitObj ? { ...hitObj } : undefined };
       }
     },
     [mode, controls, raycastCameraPlane]
@@ -511,6 +591,11 @@ function EditorSceneContent({
       {/* Ghost wire preview (add mode) */}
       {ghostWire && (
         <GhostWire start={ghostWire.start} end={ghostWire.end} />
+      )}
+
+      {/* Axis constraint indicator during drag */}
+      {axisIndicator && axisIndicator.axis && (
+        <AxisConstraintLine axis={axisIndicator.axis} position={axisIndicator.pos} />
       )}
 
       {/* Radiation pattern — surface mode */}

--- a/frontend/src/components/three/EditorScene.tsx
+++ b/frontend/src/components/three/EditorScene.tsx
@@ -316,9 +316,9 @@ function EditorSceneContent({
         const hit = raycastCameraPlane(event, anchor);
         if (!hit) return;
 
-        let dtx = hit.x - target.lastHit.x;
-        let dty = hit.y - target.lastHit.y; // Three.js Y = NEC2 Z
-        let dtz = hit.z - target.lastHit.z;
+        const dtx = hit.x - target.lastHit.x;
+        const dty = hit.y - target.lastHit.y; // Three.js Y = NEC2 Z
+        const dtz = hit.z - target.lastHit.z;
 
         // Convert to NEC2 before applying axis constraint
         // Three.js (dtx, dty, dtz) -> NEC2 (dtx, -dtz, dty)

--- a/frontend/src/components/three/EditorScene.tsx
+++ b/frontend/src/components/three/EditorScene.tsx
@@ -172,6 +172,40 @@ function EditorSceneContent({
     [raycaster, camera, snapSize]
   );
 
+  /** Raycast to a sphere surface — returns the closest NEC2 point on the sphere.
+   *  Used for length-locked endpoint dragging: the endpoint slides on the sphere. */
+  const raycastToSphere = useCallback(
+    (event: ThreeEvent<PointerEvent>, center: [number, number, number], radius: number): [number, number, number] | null => {
+      const ray = event.ray ?? raycaster.ray;
+      // Sphere center in Three.js coords: NEC2 [x, y, z] -> Three.js [x, z, -y]
+      const sphereCenter = new Vector3(center[0], center[2], -center[1]);
+      // Ray-sphere intersection: |O + tD - C|² = r²
+      const oc = new Vector3().subVectors(ray.origin, sphereCenter);
+      const a = ray.direction.dot(ray.direction);
+      const b = 2 * oc.dot(ray.direction);
+      const c = oc.dot(oc) - radius * radius;
+      const discriminant = b * b - 4 * a * c;
+
+      let hitPoint: Vector3;
+      if (discriminant >= 0) {
+        // Ray hits the sphere — use the closer intersection
+        const t = (-b - Math.sqrt(discriminant)) / (2 * a);
+        hitPoint = new Vector3().copy(ray.origin).addScaledVector(ray.direction, t > 0 ? t : (-b + Math.sqrt(discriminant)) / (2 * a));
+      } else {
+        // Ray misses — find the closest point on the sphere to the ray
+        // Project sphere center onto the ray to find closest approach
+        const tClosest = -b / (2 * a);
+        const closest = new Vector3().copy(ray.origin).addScaledVector(ray.direction, Math.max(0, tClosest));
+        // Project from center to closest point, clamp to sphere surface
+        hitPoint = new Vector3().subVectors(closest, sphereCenter).normalize().multiplyScalar(radius).add(sphereCenter);
+      }
+
+      // Three.js [x, y, z] -> NEC2 [x, -z, y]
+      return [snap(hitPoint.x, snapSize), snap(-hitPoint.z, snapSize), snap(hitPoint.y, snapSize)];
+    },
+    [raycaster, snapSize]
+  );
+
   /** Handle clicking on empty space */
   const handleBackgroundClick = useCallback(
     (event: ThreeEvent<MouseEvent>) => {
@@ -217,6 +251,32 @@ function EditorSceneContent({
         const target = dragRef.current;
         const shiftHeld = event.nativeEvent.shiftKey || verticalDrag;
 
+        // Length-locked endpoint drag: raycast directly onto the constant-length
+        // sphere for smooth movement in all directions (no Shift needed).
+        if (target.type === "endpoint") {
+          const wire = wires.find((w) => w.tag === target.tag);
+          if (wire?.lengthLocked) {
+            const { tag, endpoint } = target;
+            const fixed: [number, number, number] = endpoint === "start"
+              ? [wire.x2, wire.y2, wire.z2]
+              : [wire.x1, wire.y1, wire.z1];
+            const wireLen = Math.sqrt(
+              (wire.x2 - wire.x1) ** 2 + (wire.y2 - wire.y1) ** 2 + (wire.z2 - wire.z1) ** 2
+            );
+            if (wireLen > 1e-9) {
+              const hit = raycastToSphere(event, fixed, wireLen);
+              if (hit) {
+                if (endpoint === "start") {
+                  updateWire(tag, { x1: hit[0], y1: hit[1], z1: hit[2] });
+                } else {
+                  updateWire(tag, { x2: hit[0], y2: hit[1], z2: hit[2] });
+                }
+              }
+            }
+            return;
+          }
+        }
+
         // Shift+drag (or vertical-drag toggle on mobile) = vertical (Z-axis in NEC2) movement only
         if (shiftHeld) {
           const yVal = raycastVertical(event);
@@ -224,7 +284,6 @@ function EditorSceneContent({
 
           if (target.type === "endpoint") {
             const { tag, endpoint } = target;
-            // Only update NEC2 Z coordinate (Three.js Y)
             if (endpoint === "start") {
               updateWire(tag, { z1: yVal });
             } else {
@@ -247,7 +306,6 @@ function EditorSceneContent({
 
         if (target.type === "endpoint") {
           const { tag, endpoint } = target;
-          // Only update X/Y from ground raycast; keep the endpoint's original Z
           if (endpoint === "start") {
             updateWire(tag, { x1: pos[0], y1: pos[1], z1: target.origZ });
           } else {

--- a/frontend/src/components/three/EditorScene.tsx
+++ b/frontend/src/components/three/EditorScene.tsx
@@ -74,8 +74,15 @@ function GhostWire({ start, end }: { start: Vector3; end: Vector3 }) {
 /** Drag target: either an endpoint or the entire wire, optionally vertical-only.
  *  origZ tracks the NEC2 Z of the dragged point at drag start so we can preserve height. */
 type DragTarget =
-  | { type: "endpoint"; tag: number; endpoint: "start" | "end"; origZ: number; lastY?: number }
-  | { type: "wire"; tag: number; offsetX: number; offsetY: number; offsetZ: number; origZ: number; lastY?: number };
+  | { type: "endpoint"; tag: number; endpoint: "start" | "end";
+      /** Last camera-plane intersection in Three.js coords for delta computation */
+      lastHit?: { x: number; y: number; z: number };
+      /** NEC2 XY unit direction in the wire's horizontal plane (for Shift+lock arc) */
+      initDirX?: number; initDirY?: number;
+      /** Current angle in radians from horizontal for Shift+lock pendulum (0=horizontal, π/2=up) */
+      arcAngle?: number }
+  | { type: "wire"; tag: number;
+      lastHit?: { x: number; y: number; z: number } };
 
 /** Inner scene content — needs access to useThree */
 function EditorSceneContent({
@@ -101,6 +108,7 @@ function EditorSceneContent({
   const addWire = useEditorStore((s) => s.addWire);
   const updateWire = useEditorStore((s) => s.updateWire);
   const moveWire = useEditorStore((s) => s.moveWire);
+  const moveSelected = useEditorStore((s) => s.moveSelected);
   const toggleSelection = useEditorStore((s) => s.toggleSelection);
   const verticalDrag = useEditorStore((s) => s.verticalDrag);
   const pickingExcitationForTag = useEditorStore((s) => s.pickingExcitationForTag);
@@ -153,57 +161,21 @@ function EditorSceneContent({
     [raycaster, snapSize]
   );
 
-  /** Raycast to a camera-facing vertical plane for Shift+drag (Z-axis movement).
-   *  Returns the Y coordinate in Three.js (= Z in NEC2) for vertical offset. */
-  const raycastVertical = useCallback(
-    (event: ThreeEvent<PointerEvent>): number | null => {
+  /** Raycast to a plane perpendicular to the camera, passing through a given
+   *  Three.js world point. Returns the intersection in Three.js coordinates.
+   *  This is how Blender/Unity do 3D dragging — the object follows the mouse
+   *  naturally from any camera angle with no dead zones. */
+  const raycastCameraPlane = useCallback(
+    (event: ThreeEvent<PointerEvent | MouseEvent>, throughPoint: Vector3): Vector3 | null => {
       const intersection = new Vector3();
       const ray = event.ray ?? raycaster.ray;
-      // Build a vertical plane that faces the camera (perpendicular to camera's XZ direction)
       const camDir = new Vector3();
       camera.getWorldDirection(camDir);
-      camDir.y = 0; // project to horizontal
-      camDir.normalize();
-      const vPlane = new Plane().setFromNormalAndCoplanarPoint(camDir, new Vector3(0, 0, 0));
-      const hit = ray.intersectPlane(vPlane, intersection);
-      if (!hit) return null;
-      return snap(intersection.y, snapSize); // Three.js Y = NEC2 Z
+      const plane = new Plane().setFromNormalAndCoplanarPoint(camDir, throughPoint);
+      const hit = ray.intersectPlane(plane, intersection);
+      return hit ? intersection : null;
     },
-    [raycaster, camera, snapSize]
-  );
-
-  /** Raycast to a sphere surface — returns the closest NEC2 point on the sphere.
-   *  Used for length-locked endpoint dragging: the endpoint slides on the sphere. */
-  const raycastToSphere = useCallback(
-    (event: ThreeEvent<PointerEvent>, center: [number, number, number], radius: number): [number, number, number] | null => {
-      const ray = event.ray ?? raycaster.ray;
-      // Sphere center in Three.js coords: NEC2 [x, y, z] -> Three.js [x, z, -y]
-      const sphereCenter = new Vector3(center[0], center[2], -center[1]);
-      // Ray-sphere intersection: |O + tD - C|² = r²
-      const oc = new Vector3().subVectors(ray.origin, sphereCenter);
-      const a = ray.direction.dot(ray.direction);
-      const b = 2 * oc.dot(ray.direction);
-      const c = oc.dot(oc) - radius * radius;
-      const discriminant = b * b - 4 * a * c;
-
-      let hitPoint: Vector3;
-      if (discriminant >= 0) {
-        // Ray hits the sphere — use the closer intersection
-        const t = (-b - Math.sqrt(discriminant)) / (2 * a);
-        hitPoint = new Vector3().copy(ray.origin).addScaledVector(ray.direction, t > 0 ? t : (-b + Math.sqrt(discriminant)) / (2 * a));
-      } else {
-        // Ray misses — find the closest point on the sphere to the ray
-        // Project sphere center onto the ray to find closest approach
-        const tClosest = -b / (2 * a);
-        const closest = new Vector3().copy(ray.origin).addScaledVector(ray.direction, Math.max(0, tClosest));
-        // Project from center to closest point, clamp to sphere surface
-        hitPoint = new Vector3().subVectors(closest, sphereCenter).normalize().multiplyScalar(radius).add(sphereCenter);
-      }
-
-      // Three.js [x, y, z] -> NEC2 [x, -z, y]
-      return [snap(hitPoint.x, snapSize), snap(-hitPoint.z, snapSize), snap(hitPoint.y, snapSize)];
-    },
-    [raycaster, snapSize]
+    [raycaster, camera]
   );
 
   /** Handle clicking on empty space */
@@ -246,85 +218,125 @@ function EditorSceneContent({
         if (pos) setGhostEnd(pos);
       }
 
-      // Drag operations
+      // Drag operations — camera-facing plane approach.
+      // Raycast onto a plane perpendicular to the camera passing through
+      // the object's position. Compute delta from last hit. Apply constraints.
       if (isDragging && dragRef.current) {
         const target = dragRef.current;
-        const shiftHeld = event.nativeEvent.shiftKey || verticalDrag;
+        if (!target.lastHit) return;
 
-        // Length-locked endpoint drag: raycast directly onto the constant-length
-        // sphere for smooth movement in all directions (no Shift needed).
+        const shiftHeld = event.nativeEvent.shiftKey || verticalDrag;
+        const altHeld = event.nativeEvent.altKey;
+        const anchor = new Vector3(target.lastHit.x, target.lastHit.y, target.lastHit.z);
+
+        // Camera-facing plane for all modes — orbit controls are disabled
+        // during dragging so the plane stays stable between frames.
+        const hit = raycastCameraPlane(event, anchor);
+        if (!hit) return;
+
+        let dtx = hit.x - target.lastHit.x;
+        let dty = hit.y - target.lastHit.y;
+        let dtz = hit.z - target.lastHit.z;
+
+        if (shiftHeld) {
+          dtx = 0; dtz = 0;
+          target.lastHit = { x: target.lastHit.x, y: hit.y, z: target.lastHit.z };
+        } else if (altHeld) {
+          dty = 0;
+          target.lastHit = { x: hit.x, y: target.lastHit.y, z: hit.z };
+        } else {
+          target.lastHit = { x: hit.x, y: hit.y, z: hit.z };
+        }
+
+        // Convert delta: Three.js (dtx, dty, dtz) -> NEC2 (dtx, -dtz, dty)
+        const necDx = dtx;
+        const necDy = -dtz;
+        const necDz = dty;
+
+        if (Math.abs(necDx) < 1e-9 && Math.abs(necDy) < 1e-9 && Math.abs(necDz) < 1e-9) return;
+
         if (target.type === "endpoint") {
-          const wire = wires.find((w) => w.tag === target.tag);
-          if (wire?.lengthLocked) {
-            const { tag, endpoint } = target;
-            const fixed: [number, number, number] = endpoint === "start"
+          const { tag, endpoint } = target;
+          const wire = wires.find((w) => w.tag === tag);
+          if (!wire) return;
+
+          let newX = (endpoint === "start" ? wire.x1 : wire.x2) + necDx;
+          let newY = (endpoint === "start" ? wire.y1 : wire.y2) + necDy;
+          let newZ = (endpoint === "start" ? wire.z1 : wire.z2) + necDz;
+
+          // Length lock: maintain wire length while respecting axis constraints
+          if (wire.lengthLocked) {
+            const [fx, fy, fz] = endpoint === "start"
               ? [wire.x2, wire.y2, wire.z2]
               : [wire.x1, wire.y1, wire.z1];
             const wireLen = Math.sqrt(
               (wire.x2 - wire.x1) ** 2 + (wire.y2 - wire.y1) ** 2 + (wire.z2 - wire.z1) ** 2
             );
             if (wireLen > 1e-9) {
-              const hit = raycastToSphere(event, fixed, wireLen);
-              if (hit) {
-                if (endpoint === "start") {
-                  updateWire(tag, { x1: hit[0], y1: hit[1], z1: hit[2] });
-                } else {
-                  updateWire(tag, { x2: hit[0], y2: hit[1], z2: hit[2] });
+              if (altHeld) {
+                // Horizontal only: keep Z fixed, scale XY to maintain length
+                const dz = newZ - fz;
+                const hNeededSq = wireLen * wireLen - dz * dz;
+                if (hNeededSq > 0) {
+                  const hx = newX - fx, hy = newY - fy;
+                  const hDist = Math.sqrt(hx * hx + hy * hy);
+                  if (hDist > 1e-9) {
+                    const scale = Math.sqrt(hNeededSq) / hDist;
+                    newX = fx + hx * scale;
+                    newY = fy + hy * scale;
+                  }
+                }
+              } else if (shiftHeld) {
+                // Vertical arc: update the angle from Z delta, compute
+                // position on the circle. Full 360° rotation.
+                const prevAngle = target.arcAngle ?? 0;
+                const angleDelta = necDz / wireLen; // scale Z delta to angle
+                const angle = prevAngle + angleDelta;
+                target.arcAngle = angle;
+                const dirX = target.initDirX ?? 1;
+                const dirY = target.initDirY ?? 0;
+                newX = fx + dirX * wireLen * Math.cos(angle);
+                newY = fy + dirY * wireLen * Math.cos(angle);
+                newZ = fz + wireLen * Math.sin(angle);
+              } else {
+                // Free movement: project onto sphere
+                const dx = newX - fx, dy = newY - fy, dz = newZ - fz;
+                const dist = Math.sqrt(dx * dx + dy * dy + dz * dz);
+                if (dist > 1e-9) {
+                  const scale = wireLen / dist;
+                  newX = fx + dx * scale;
+                  newY = fy + dy * scale;
+                  newZ = fz + dz * scale;
                 }
               }
             }
-            return;
           }
-        }
 
-        // Shift+drag (or vertical-drag toggle on mobile) = vertical (Z-axis in NEC2) movement only
-        if (shiftHeld) {
-          const yVal = raycastVertical(event);
-          if (yVal === null) return;
-
-          if (target.type === "endpoint") {
-            const { tag, endpoint } = target;
-            if (endpoint === "start") {
-              updateWire(tag, { z1: yVal });
-            } else {
-              updateWire(tag, { z2: yVal });
-            }
-          } else if (target.type === "wire") {
-            const lastY = target.lastY ?? yVal;
-            const dz = yVal - lastY; // NEC2 dz = Three.js dy
-            if (dz !== 0) {
-              moveWire(target.tag, 0, 0, dz);
-            }
-            target.lastY = yVal;
-          }
-          return;
-        }
-
-        // Normal drag on ground plane (horizontal X/Y movement only — preserve Z height)
-        const pos = raycastToGround(event);
-        if (!pos) return;
-
-        if (target.type === "endpoint") {
-          const { tag, endpoint } = target;
           if (endpoint === "start") {
-            updateWire(tag, { x1: pos[0], y1: pos[1], z1: target.origZ });
+            updateWire(tag, { x1: newX, y1: newY, z1: newZ });
           } else {
-            updateWire(tag, { x2: pos[0], y2: pos[1], z2: target.origZ });
+            updateWire(tag, { x2: newX, y2: newY, z2: newZ });
+          }
+
+          // Length-lock projection moves the endpoint to a different position
+          // than the raw camera-plane hit. Re-sync lastHit to the actual
+          // endpoint so the next frame's delta starts from where it really is.
+          // Exception: Shift uses angle tracking where lastHit must stay on
+          // the camera plane for consistent sensitivity through 360°.
+          if (wire.lengthLocked && target.lastHit && !shiftHeld) {
+            // NEC2 (newX, newY, newZ) -> Three.js (newX, newZ, -newY)
+            target.lastHit = { x: newX, y: newZ, z: -newY };
           }
         } else if (target.type === "wire") {
-          // Whole-wire move: only apply horizontal delta (X/Y), preserve Z
-          const dx = pos[0] - target.offsetX;
-          const dy = pos[1] - target.offsetY;
-          if (dx !== 0 || dy !== 0) {
-            moveWire(target.tag, dx, dy, 0);
+          if (selectedTags.size > 1 && selectedTags.has(target.tag)) {
+            moveSelected(necDx, necDy, necDz);
+          } else {
+            moveWire(target.tag, necDx, necDy, necDz);
           }
-          // Update offset to current position for next delta
-          target.offsetX = pos[0];
-          target.offsetY = pos[1];
         }
       }
     },
-    [mode, addStart, isDragging, verticalDrag, raycastToGround, raycastVertical, updateWire, moveWire]
+    [mode, addStart, isDragging, verticalDrag, snapSize, wires, selectedTags, raycastToGround, raycastCameraPlane, updateWire, moveWire, moveSelected]
   );
 
   const handlePointerUp = useCallback(() => {
@@ -352,19 +364,37 @@ function EditorSceneContent({
 
   /** Handle endpoint drag start (move mode — endpoint only) */
   const handleEndpointDragStart = useCallback(
-    (tag: number, endpoint: "start" | "end", _event: ThreeEvent<PointerEvent>) => {
+    (tag: number, endpoint: "start" | "end", event: ThreeEvent<PointerEvent>) => {
       if (mode === "move") {
-        // Capture the endpoint's current NEC2 Z so we can preserve it during horizontal drags
         const wire = wires.find((w) => w.tag === tag);
-        const origZ = wire ? (endpoint === "start" ? wire.z1 : wire.z2) : 0;
-        // Imperatively disable orbit controls before the React re-render — prevents
-        // touch devices from simultaneously orbiting the camera during a wire drag.
+        // Use actual click point on the endpoint sphere as camera-plane anchor
+        const ep = event.point ?? (wire
+          ? (endpoint === "start" ? new Vector3(wire.x1, wire.z1, -wire.y1) : new Vector3(wire.x2, wire.z2, -wire.y2))
+          : new Vector3());
+        const hit = raycastCameraPlane(event, ep);
+        // Capture initial XY direction for length-lock fallback when XY shrinks to 0
+        let initDirX = 0, initDirY = 0;
+        if (wire) {
+          const [fx, fy] = endpoint === "start" ? [wire.x2, wire.y2] : [wire.x1, wire.y1];
+          const [mx, my] = endpoint === "start" ? [wire.x1, wire.y1] : [wire.x2, wire.y2];
+          const hd = Math.sqrt((mx - fx) ** 2 + (my - fy) ** 2);
+          if (hd > 1e-9) { initDirX = (mx - fx) / hd; initDirY = (my - fy) / hd; }
+          else { initDirX = 1; initDirY = 0; }
+        }
+        // Compute initial arc angle for Shift+lock pendulum
+        let arcAngle = 0;
+        if (wire) {
+          const [fx2, fy2, fz2] = endpoint === "start" ? [wire.x2, wire.y2, wire.z2] : [wire.x1, wire.y1, wire.z1];
+          const [mx2, my2, mz2] = endpoint === "start" ? [wire.x1, wire.y1, wire.z1] : [wire.x2, wire.y2, wire.z2];
+          const hd2 = Math.sqrt((mx2 - fx2) ** 2 + (my2 - fy2) ** 2);
+          arcAngle = Math.atan2(mz2 - fz2, hd2);
+        }
         if (controls) (controls as unknown as { enabled: boolean }).enabled = false;
         setIsDragging(true);
-        dragRef.current = { type: "endpoint", tag, endpoint, origZ };
+        dragRef.current = { type: "endpoint", tag, endpoint, initDirX, initDirY, arcAngle, lastHit: hit ? { x: hit.x, y: hit.y, z: hit.z } : undefined };
       }
     },
-    [mode, wires, controls]
+    [mode, wires, controls, raycastCameraPlane]
   );
 
   /** Handle wire body drag start (move mode — whole wire) */
@@ -372,27 +402,17 @@ function EditorSceneContent({
     (tag: number, event: ThreeEvent<PointerEvent>) => {
       if (mode === "move") {
         event.stopPropagation();
-        const pos = raycastToGround(event);
-        if (!pos) return;
-        const yVal = raycastVertical(event);
-        // Capture wire's average Z so Shift+drag has a baseline
-        const wire = wires.find((w) => w.tag === tag);
-        const origZ = wire ? (wire.z1 + wire.z2) / 2 : 0;
-        // Imperatively disable orbit controls before the React re-render
+        // Use the actual click point on the wire tube as the anchor.
+        // This matches the camera-plane depth to where the user clicked,
+        // giving 1:1 cursor tracking without sensitivity jumps.
+        const clickPoint = event.point ?? new Vector3();
+        const hit = raycastCameraPlane(event, clickPoint);
         if (controls) (controls as unknown as { enabled: boolean }).enabled = false;
         setIsDragging(true);
-        dragRef.current = {
-          type: "wire",
-          tag,
-          offsetX: pos[0],
-          offsetY: pos[1],
-          offsetZ: pos[2],
-          origZ,
-          lastY: yVal ?? undefined,
-        };
+        dragRef.current = { type: "wire", tag, lastHit: hit ? { x: hit.x, y: hit.y, z: hit.z } : undefined };
       }
     },
-    [mode, wires, raycastToGround, raycastVertical, controls]
+    [mode, controls, raycastCameraPlane]
   );
 
   // Convert wires to WireData format

--- a/frontend/src/pages/EditorPage.tsx
+++ b/frontend/src/pages/EditorPage.tsx
@@ -394,7 +394,7 @@ export function EditorPage() {
               )}
               {mode === "move" && (
                 <span className="text-text-secondary ml-1">
-                  <span className="hidden lg:inline">(Shift = vertical)</span>
+                  <span className="hidden lg:inline">(Shift = vertical, Alt = horizontal)</span>
                   <span className="lg:hidden">{verticalDrag ? "(vertical)" : "(horizontal)"}</span>
                 </span>
               )}

--- a/frontend/src/pages/EditorPage.tsx
+++ b/frontend/src/pages/EditorPage.tsx
@@ -394,8 +394,8 @@ export function EditorPage() {
               )}
               {mode === "move" && (
                 <span className="text-text-secondary ml-1">
-                  <span className="hidden lg:inline">(Shift = vertical, Alt = horizontal)</span>
-                  <span className="lg:hidden">{verticalDrag ? "(vertical)" : "(horizontal)"}</span>
+                  <span className="hidden lg:inline">(X/Y/Z = lock axis, Shift+X/Y/Z = exclude axis)</span>
+                  <span className="lg:hidden">{verticalDrag ? "(vertical)" : "(drag to move)"}</span>
                 </span>
               )}
             </div>

--- a/frontend/src/stores/editorStore.ts
+++ b/frontend/src/stores/editorStore.ts
@@ -28,6 +28,8 @@ export interface EditorWire extends WireGeometry {
   selected?: boolean;
   /** Whether segments were manually set by the user (sticky override) */
   segmentsManual?: boolean;
+  /** Whether wire length is locked during endpoint drags */
+  lengthLocked?: boolean;
 }
 
 /** A snapshot of the editor state for undo/redo */
@@ -161,6 +163,14 @@ interface EditorState {
 
   // ---- V2: Currents ----
   setComputeCurrents: (compute: boolean) => void;
+
+  // ---- Wire Length ----
+  /** Set wire to a specific length, keeping the anchor endpoint fixed */
+  setWireLength: (tag: number, length: number, anchor: "start" | "end") => void;
+  /** Toggle length lock on a wire */
+  toggleLengthLock: (tag: number) => void;
+  /** Bend a wire: split at position and rotate the second half by angle */
+  bendWire: (tag: number, position: number, angleDeg: number, plane: "horizontal" | "vertical", numSegments?: number) => void;
 
   // ---- Clipboard / Transform ----
   /** Clipboard for copy/paste */
@@ -444,6 +454,141 @@ export const useEditorStore = create<EditorState>((set, get) => ({
       excitations: newExcitations,
       selectedTags: newSelected,
       nextTag: tag2 + 1,
+    });
+  },
+
+  setWireLength: (tag, length, anchor) => {
+    const state = get();
+    const wire = state.wires.find((w) => w.tag === tag);
+    if (!wire || length <= 0) return;
+
+    // Anchor is the fixed end; the other end moves along the direction vector
+    const [ax, ay, az] = anchor === "start"
+      ? [wire.x1, wire.y1, wire.z1]
+      : [wire.x2, wire.y2, wire.z2];
+    const [mx, my, mz] = anchor === "start"
+      ? [wire.x2, wire.y2, wire.z2]
+      : [wire.x1, wire.y1, wire.z1];
+
+    let dx = mx - ax, dy = my - ay, dz = mz - az;
+    const dist = Math.sqrt(dx * dx + dy * dy + dz * dz);
+
+    if (dist < 1e-9) {
+      // Zero-length wire: extend along +Z
+      dx = 0; dy = 0; dz = 1;
+    } else {
+      dx /= dist; dy /= dist; dz /= dist;
+    }
+
+    const newX = ax + dx * length;
+    const newY = ay + dy * length;
+    const newZ = az + dz * length;
+
+    const updates: Partial<EditorWire> = anchor === "start"
+      ? { x2: newX, y2: newY, z2: newZ }
+      : { x1: newX, y1: newY, z1: newZ };
+
+    const newWires = state.wires.map((w) => {
+      if (w.tag !== tag) return w;
+      const updated = { ...w, ...updates };
+      if (!w.segmentsManual) {
+        updated.segments = computeSegments(updated, state.designFrequencyMhz);
+      }
+      return updated;
+    });
+
+    set({ ...pushUndo(state), wires: newWires });
+  },
+
+  toggleLengthLock: (tag) => {
+    const state = get();
+    const newWires = state.wires.map((w) =>
+      w.tag === tag ? { ...w, lengthLocked: !w.lengthLocked } : w
+    );
+    set({ ...pushUndo(state), wires: newWires });
+  },
+
+  bendWire: (tag, _position, angleDeg, plane, numSegments = 2) => {
+    const state = get();
+    const wire = state.wires.find((w) => w.tag === tag);
+    if (!wire || numSegments < 2) return;
+
+    const n = Math.min(numSegments, 20);
+
+    const totalDx = wire.x2 - wire.x1, totalDy = wire.y2 - wire.y1, totalDz = wire.z2 - wire.z1;
+    const totalLen = Math.sqrt(totalDx * totalDx + totalDy * totalDy + totalDz * totalDz);
+    if (totalLen < 1e-9) return;
+
+    // Equal-length segments, bend angle distributed at each joint
+    const segmentLen = totalLen / n;
+    const anglePerJoint = (angleDeg * Math.PI) / 180 / (n - 1);
+
+    // Helper: rotate direction vector in the chosen plane
+    const rotateDir = (dx: number, dy: number, dz: number, angle: number): [number, number, number] => {
+      const cos = Math.cos(angle), sin = Math.sin(angle);
+      if (plane === "horizontal") {
+        return [dx * cos - dy * sin, dx * sin + dy * cos, dz];
+      }
+      const hLen = Math.sqrt(dx * dx + dy * dy);
+      if (hLen < 1e-9) {
+        return [dz * sin, 0, dz * cos];
+      }
+      const hx = dx / hLen, hy = dy / hLen;
+      const newH = hLen * cos - dz * sin;
+      const newV = hLen * sin + dz * cos;
+      return [hx * newH, hy * newH, newV];
+    };
+
+    let dirX = totalDx / totalLen, dirY = totalDy / totalLen, dirZ = totalDz / totalLen;
+    let curX = wire.x1, curY = wire.y1, curZ = wire.z1;
+
+    const newWiresList: EditorWire[] = [];
+    const newSelected = new Set(state.selectedTags);
+    newSelected.delete(tag);
+    let nextTag = state.nextTag;
+
+    for (let i = 0; i < n; i++) {
+      if (i > 0) {
+        [dirX, dirY, dirZ] = rotateDir(dirX, dirY, dirZ, anglePerJoint);
+      }
+
+      const endX = curX + dirX * segmentLen;
+      const endY = curY + dirY * segmentLen;
+      const endZ = curZ + dirZ * segmentLen;
+
+      const newTag = nextTag++;
+      newWiresList.push({
+        ...wire,
+        tag: newTag,
+        x1: curX, y1: curY, z1: curZ,
+        x2: endX, y2: endY, z2: endZ,
+        segments: computeSegments(
+          { x1: curX, y1: curY, z1: curZ, x2: endX, y2: endY, z2: endZ },
+          state.designFrequencyMhz,
+        ),
+        segmentsManual: false,
+      });
+      newSelected.add(newTag);
+
+      curX = endX; curY = endY; curZ = endZ;
+    }
+
+    // Remap excitations: assign to the first new wire at a scaled segment
+    const newExcitations = state.excitations.map((e) => {
+      if (e.wire_tag !== tag) return e;
+      const firstWire = newWiresList[0]!;
+      const ratio = e.segment / wire.segments;
+      return { ...e, wire_tag: firstWire.tag, segment: Math.max(1, Math.min(firstWire.segments, Math.round(ratio * firstWire.segments))) };
+    });
+
+    const newWires = state.wires.filter((w) => w.tag !== tag).concat(newWiresList);
+
+    set({
+      ...pushUndo(state),
+      wires: newWires,
+      excitations: newExcitations,
+      selectedTags: newSelected,
+      nextTag,
     });
   },
 

--- a/frontend/src/stores/editorStore.ts
+++ b/frontend/src/stores/editorStore.ts
@@ -100,6 +100,8 @@ interface EditorState {
   deleteSelected: () => void;
   /** Move an entire wire by a delta in NEC2 coordinates */
   moveWire: (tag: number, dx: number, dy: number, dz: number) => void;
+  /** Move all selected wires by the same delta */
+  moveSelected: (dx: number, dy: number, dz: number) => void;
   /** Move ALL wires by a delta in NEC2 Z (height) */
   moveAllWiresZ: (dz: number) => void;
   /** Split a wire at its midpoint into two wires */
@@ -354,6 +356,18 @@ export const useEditorStore = create<EditorState>((set, get) => ({
 
     const newWires = [...state.wires];
     newWires[idx] = updated;
+    set({ ...pushUndo(state), wires: newWires });
+  },
+
+  moveSelected: (dx, dy, dz) => {
+    const state = get();
+    if (state.selectedTags.size === 0) return;
+    if (dx === 0 && dy === 0 && dz === 0) return;
+    const newWires = state.wires.map((w) =>
+      state.selectedTags.has(w.tag)
+        ? { ...w, x1: w.x1 + dx, y1: w.y1 + dy, z1: w.z1 + dz, x2: w.x2 + dx, y2: w.y2 + dy, z2: w.z2 + dz }
+        : w
+    );
     set({ ...pushUndo(state), wires: newWires });
   },
 

--- a/frontend/src/stores/editorStore.ts
+++ b/frontend/src/stores/editorStore.ts
@@ -173,6 +173,8 @@ interface EditorState {
   toggleLengthLock: (tag: number) => void;
   /** Bend a wire: split at position and rotate the second half by angle */
   bendWire: (tag: number, position: number, angleDeg: number, plane: "horizontal" | "vertical", numSegments?: number) => void;
+  /** Simulate wire hanging between its endpoints with gravity sag */
+  hangWire: (tag: number, numSegments: number, targetLength?: number) => void;
 
   // ---- Clipboard / Transform ----
   /** Clipboard for copy/paste */
@@ -597,6 +599,89 @@ export const useEditorStore = create<EditorState>((set, get) => ({
 
     const newWires = state.wires.filter((w) => w.tag !== tag).concat(newWiresList);
 
+    set({
+      ...pushUndo(state),
+      wires: newWires,
+      excitations: newExcitations,
+      selectedTags: newSelected,
+      nextTag,
+    });
+  },
+
+  hangWire: (tag, numSegments, targetLength) => {
+    const state = get();
+    const wire = state.wires.find((w) => w.tag === tag);
+    if (!wire || numSegments < 2) return;
+
+    const n = Math.min(numSegments, 30);
+
+    // Endpoints (NEC2 coords)
+    const ax = wire.x1, ay = wire.y1, az = wire.z1;
+    const bx = wire.x2, by = wire.y2, bz = wire.z2;
+
+    // Use target length if provided, otherwise current wire length
+    const currentLen = Math.sqrt((bx - ax) ** 2 + (by - ay) ** 2 + (bz - az) ** 2);
+    const wireLen = targetLength ?? currentLen;
+    if (wireLen < 1e-9) return;
+
+    // Horizontal span (XY distance) and vertical difference
+    const hSpan = Math.sqrt((bx - ax) ** 2 + (by - ay) ** 2);
+    const vDiff = bz - az; // height difference
+
+    // Straight-line 3D span
+    const span = Math.sqrt(hSpan * hSpan + vDiff * vDiff);
+
+    // Sag: parabolic approximation. If wire is taut (L ≈ span), minimal sag.
+    // maxSag = sqrt(3 * span * (wireLen - span) / 8)
+    const slack = Math.max(0, wireLen - span);
+    const maxSag = slack > 1e-6 ? Math.sqrt(3 * span * slack / 8) : 0;
+
+    // Build points along the catenary/parabolic curve
+    const points: Array<{ x: number; y: number; z: number }> = [];
+    for (let i = 0; i <= n; i++) {
+      const t = i / n;
+      // Linear interpolation for the straight-line baseline
+      const lx = ax + (bx - ax) * t;
+      const ly = ay + (by - ay) * t;
+      const lz = az + (bz - az) * t;
+      // Parabolic sag below the baseline (4*s*t*(1-t) peaks at midpoint)
+      const sag = 4 * maxSag * t * (1 - t);
+      points.push({ x: lx, y: ly, z: lz - sag });
+    }
+
+    // Create wire segments
+    const newWiresList: EditorWire[] = [];
+    const newSelected = new Set(state.selectedTags);
+    newSelected.delete(tag);
+    let nextTag = state.nextTag;
+
+    for (let i = 0; i < n; i++) {
+      const p1 = points[i]!, p2 = points[i + 1]!;
+      const newTag = nextTag++;
+      newWiresList.push({
+        ...wire,
+        tag: newTag,
+        x1: p1.x, y1: p1.y, z1: p1.z,
+        x2: p2.x, y2: p2.y, z2: p2.z,
+        segments: computeSegments(
+          { x1: p1.x, y1: p1.y, z1: p1.z, x2: p2.x, y2: p2.y, z2: p2.z },
+          state.designFrequencyMhz,
+        ),
+        segmentsManual: false,
+        lengthLocked: false,
+      });
+      newSelected.add(newTag);
+    }
+
+    // Remap excitations to first segment
+    const newExcitations = state.excitations.map((e) => {
+      if (e.wire_tag !== tag) return e;
+      const firstWire = newWiresList[0]!;
+      const ratio = e.segment / wire.segments;
+      return { ...e, wire_tag: firstWire.tag, segment: Math.max(1, Math.min(firstWire.segments, Math.round(ratio * firstWire.segments))) };
+    });
+
+    const newWires = state.wires.filter((w) => w.tag !== tag).concat(newWiresList);
     set({
       ...pushUndo(state),
       wires: newWires,


### PR DESCRIPTION
## Summary

  Wire editor overhaul with new tools and improved drag mechanics:

  - **Editable wire length** in properties panel and wire table
  - **Length lock** toggle to constrain endpoint drags to constant wire length
  - **Bend wire** tool — split a wire into equal-length segments at a configurable angle (horizontal/vertical)
  - **Hang wire** tool — simulate catenary sag between endpoints with adjustable wire length and segment count
  - **Blender-style axis constraints** — press X/Y/Z during drag to lock to that axis, Shift+X/Y/Z to exclude an axis, with colored axis indicator lines
  - **Camera-facing plane dragging** — endpoints and wires follow the mouse 1:1 from any camera angle
  - **Multi-wire move** — dragging one wire in a multi-selection moves all selected wires together
  - **Fixed wire drag anchor** — whole-wire movement no longer drifts from the cursor

  Closes #46