### PR TITLE
feat(results): add Export .s1p button to results panel

### DIFF
--- a/frontend/src/components/results/ResultsTabs.tsx
+++ b/frontend/src/components/results/ResultsTabs.tsx
@@ -17,6 +17,7 @@ import { useSimulationStore } from "../../stores/simulationStore";
 import { useUIStore, type ResultsTab } from "../../stores/uiStore";
 import { formatSwr, formatImpedance, formatGain, swrColorClass, applyMatching } from "../../utils/units";
 import { parseS1P } from "../../utils/s1p-parser";
+import { downloadResultsS1P } from "../../utils/s1p-export";
 
 const TABS = [
   { key: "swr", label: "SWR" },
@@ -83,6 +84,11 @@ export function ResultsPanel() {
   const handleS1PClear = useCallback(() => {
     setS1PFile(null);
   }, [setS1PFile]);
+
+  const handleS1PExport = useCallback(() => {
+    if (!result) return;
+    downloadResultsS1P(result.frequency_data, matching);
+  }, [result, matching]);
 
   return (
     <div className="flex flex-col h-full overflow-hidden">
@@ -171,6 +177,13 @@ export function ResultsPanel() {
                       {formatImpedance(m.real, m.imag)}
                     </div>
                   </div>
+                  <button
+                    onClick={handleS1PExport}
+                    className="col-span-2 text-[10px] px-1.5 py-1 rounded border border-border text-text-secondary hover:text-text-primary hover:border-accent/50 transition-colors"
+                    title="Export sweep as Touchstone .s1p"
+                  >
+                    Export .s1p
+                  </button>
                 </div>
               );
             })()}

--- a/frontend/src/utils/s1p-export.ts
+++ b/frontend/src/utils/s1p-export.ts
@@ -1,0 +1,62 @@
+/**
+ * Touchstone .s1p export for simulation results.
+ *
+ * Writes S11 (reflection coefficient) vs frequency in RI format, referenced
+ * to the feedline impedance, i.e. the same values shown in the results
+ * summary panel (post-matching, if a balun/unun is configured).
+ */
+
+import type { FrequencyResult } from "../api/nec";
+import { applyMatching, type MatchingConfig, DEFAULT_MATCHING } from "./units";
+import { downloadTextFile } from "./csv-export";
+
+/** Convert complex impedance to S11 relative to a reference impedance. */
+function impedanceToS11(
+  zReal: number,
+  zImag: number,
+  z0: number
+): { real: number; imag: number } {
+  const numReal = zReal - z0;
+  const numImag = zImag;
+  const denReal = zReal + z0;
+  const denImag = zImag;
+  const denMagSq = denReal * denReal + denImag * denImag;
+  if (denMagSq < 1e-30) return { real: 1, imag: 0 };
+  return {
+    real: (numReal * denReal + numImag * denImag) / denMagSq,
+    imag: (numImag * denReal - numReal * denImag) / denMagSq,
+  };
+}
+
+/** Build a Touchstone .s1p file (RI format) from simulation results. */
+export function exportResultsS1P(
+  data: FrequencyResult[],
+  matching: MatchingConfig = DEFAULT_MATCHING
+): string {
+  const z0 = matching.feedlineZ0;
+  const lines = [
+    "! Touchstone S1P export",
+    `! Frequency (MHz), S11 real, S11 imag, reference impedance ${z0} ohms`,
+    `# MHZ S RI R ${z0}`,
+  ];
+
+  for (const d of data) {
+    const m = applyMatching(d.impedance.real, d.impedance.imag, matching);
+    const s11 = impedanceToS11(m.real, m.imag, z0);
+    lines.push(
+      `${d.frequency_mhz.toFixed(6)} ${s11.real.toFixed(6)} ${s11.imag.toFixed(6)}`
+    );
+  }
+
+  return lines.join("\n") + "\n";
+}
+
+/** Export and download simulation results as a Touchstone .s1p file */
+export function downloadResultsS1P(
+  data: FrequencyResult[],
+  matching: MatchingConfig = DEFAULT_MATCHING,
+  filename: string = "antsim-results.s1p"
+): void {
+  const s1p = exportResultsS1P(data, matching);
+  downloadTextFile(s1p, filename, "text/plain");
+}


### PR DESCRIPTION
  ## Summary
This provides an export utility (`frontend/src/utils/s1p-export.ts`) to write the frequency sweep as a Touchstone RI-format `.s1p` file referenced to the feedline impedance (i.e. reflects any configured balun/unun matching), and a "Export .s1p" button to the always-visible SWR/Gain/Impedance summary at the top of the results panel to export these data.

  ## Testing
  - `npm run type-check`, `npm run lint`, `npm run build` all pass
  - Manually verified in the Docker dev environment (`./scripts/dev.sh`):
    ran a simulation, clicked "Export .s1p", confirmed the downloaded
    file opens with correct frequency/S11 values.